### PR TITLE
fix: align footer audio/name/command button

### DIFF
--- a/src/components/templates/Layout/Identity.tsx
+++ b/src/components/templates/Layout/Identity.tsx
@@ -22,7 +22,7 @@ const openCommandPalette = () =>
 export default function Identity({ onCommand }: IdentityProps) {
   return (
     <footer className={styles.footer}>
-      <AudioToggle />
+      <AudioToggle className={styles.footerAction} />
 
       <div className={styles.name}>
         <GlitchText text="IVAN DEL FATTI" />
@@ -31,6 +31,7 @@ export default function Identity({ onCommand }: IdentityProps) {
       <Button
         variant="ghost"
         stamp={false}
+        className={styles.footerAction}
         onClick={() => {
           onCommand?.();
           openCommandPalette();

--- a/src/components/templates/Layout/layout.module.scss
+++ b/src/components/templates/Layout/layout.module.scss
@@ -270,6 +270,7 @@
 .footer {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: $spacing-sm;
 
   .name {
@@ -282,6 +283,13 @@
     font-size: $font-size-sm;
     opacity: 0.6;
   }
+}
+
+// Optically align padded ghost buttons (audio toggle, ⌘K) with the plain-text
+// name: pull them left by the button's horizontal padding so all footer text
+// shares the same left edge (desktop rail + mobile overlay).
+.footerAction {
+  margin-left: -$spacing-md;
 }
 
 .socials {


### PR DESCRIPTION
Sul rail di sinistra (e nell'overlay mobile) play/pause, nome e bottone ⌘K non erano allineati: i bottoni ghost hanno padding orizzontale, il nome è testo puro.

Fix: classe condivisa `.footerAction` (margine negativo pari al padding del bottone) passata ad AudioToggle e al bottone ⌘K, così tutto il testo del footer condivide lo stesso bordo sinistro.

## Verifica
- `npm run build` ok
- `npm test` 136/136