### PR TITLE
refactor: consolidate token scales + consistent ink on chrome

### DIFF
--- a/src/app/admin/login/page.module.scss
+++ b/src/app/admin/login/page.module.scss
@@ -67,7 +67,7 @@
   max-width: 420px;
   background-color: var(--color-card-bg);
   border: $border-hairline solid var(--color-divider);
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   padding: 2.5rem 2rem;
   position: relative;
 
@@ -203,7 +203,7 @@
   color: var(--color-bg);
   background-color: var(--color-accent);
   padding: 0.1rem 0.4rem;
-  border-radius: $radius-xs;
+  border-radius: $radius-sm;
 }
 
 .demoLabel {

--- a/src/app/admin/page.module.scss
+++ b/src/app/admin/page.module.scss
@@ -274,7 +274,7 @@
   font-size: $font-size-xs;
   padding: 0.25rem 0.5rem;
   border: $border-hairline solid;
-  border-radius: $radius-xs;
+  border-radius: $radius-sm;
   background: transparent;
   cursor: pointer;
   transition: background-color 0.15s, color 0.15s;
@@ -305,7 +305,7 @@
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur($blur-xs);
+  backdrop-filter: blur($blur-sm);
   z-index: 100;
   display: flex;
   align-items: flex-start;
@@ -320,7 +320,7 @@
   background-color: var(--color-card-bg);
   border: $border-hairline solid var(--color-divider);
   border-top: $border-base solid var(--color-accent);
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   position: relative;
 }
 
@@ -481,7 +481,7 @@
   background-color: var(--color-card-bg);
   border: $border-hairline solid rgba($color-destructive-light, 0.4);
   border-top: $border-base solid $color-destructive-light;
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   padding: 1.75rem 2rem;
   width: 100%;
   max-width: 380px;

--- a/src/app/lab/[slug]/ProjectDetail.module.scss
+++ b/src/app/lab/[slug]/ProjectDetail.module.scss
@@ -260,7 +260,7 @@
   letter-spacing: $letter-spacing-xl;
   text-decoration: none;
   padding: 0.65rem 1.25rem;
-  border-radius: var(--route-card-radius, #{$radius-xl});
+  border-radius: var(--route-card-radius, #{$radius-lg});
   border: $border-base solid var(--color-text);
   box-shadow: var(--depth-sm);
   transition: box-shadow 0.12s ease, transform 0.12s ease, opacity 0.15s ease;

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -104,7 +104,7 @@
     background: var(--color-card-bg);
     border: $border-hairline solid var(--color-divider);
     border-radius: $radius-sm;
-    padding: $spacing-3xs $spacing-xs;
+    padding: $spacing-2xs $spacing-xs;
     color: var(--color-accent);
     box-shadow: 0 1px 2px color.adjust($color-black, $alpha: -0.9);
   }

--- a/src/app/secrets/page.module.scss
+++ b/src/app/secrets/page.module.scss
@@ -16,7 +16,7 @@
   width: 100%;
   max-width: 800px;
   border: $border-base solid $effect-terminal-green;
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   padding: $spacing-md;
   background: color.adjust($effect-terminal-green, $alpha: -0.95);
   box-shadow: 0 0 20px color.adjust($effect-terminal-green, $alpha: -0.8);

--- a/src/app/time-machine/TimeMachine.module.scss
+++ b/src/app/time-machine/TimeMachine.module.scss
@@ -164,7 +164,7 @@
   letter-spacing: $letter-spacing-lg;
   background: color.adjust($color-lario-light, $alpha: -0.9);
   padding: $spacing-xs $spacing-sm;
-  border-radius: $radius-xs;
+  border-radius: $radius-sm;
   border: $border-hairline solid color.adjust($color-lario-light, $alpha: -0.8);
 }
 
@@ -254,7 +254,7 @@
 
 .tvBezel {
   background: linear-gradient(145deg, #2a2a2a 0%, #1a1a1a 50%, #111 100%);
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   padding: 28px 28px 52px;
   box-shadow:
     0 0 0 2px #3a3a3a,

--- a/src/components/atoms/button/Button.module.scss
+++ b/src/components/atoms/button/Button.module.scss
@@ -11,7 +11,7 @@
   padding: $spacing-sm $spacing-md;
   cursor: pointer;
   border: $border-base solid transparent;
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   text-decoration: none;
   color: var(--color-text);
   font-family: $font-family-mono;

--- a/src/components/molecules/audio-prompt/AudioPrompt.module.scss
+++ b/src/components/molecules/audio-prompt/AudioPrompt.module.scss
@@ -14,7 +14,7 @@
 .modal {
   background: var(--color-card-bg);
   border: $border-hairline solid var(--color-card-border);
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   padding: 40px;
   max-width: 400px;
   width: 90%;
@@ -22,8 +22,8 @@
   box-shadow: 0 25px 50px -12px rgba(var(--color-silk-rgb), 0.6);
 
   .icon {
-    width: $spacing-3xl;
-    height: $spacing-3xl;
+    width: $spacing-2xl;
+    height: $spacing-2xl;
     margin: 0 auto 20px;
     color: var(--color-accent);
 

--- a/src/components/molecules/gallery-viewer/GalleryViewer.module.scss
+++ b/src/components/molecules/gallery-viewer/GalleryViewer.module.scss
@@ -7,7 +7,7 @@
   flex-direction: column;
   gap: $spacing-sm;
   width: 100%;
-  padding-top: $spacing-3xs;
+  padding-top: $spacing-2xs;
   outline: none;
 
   &:focus-visible {

--- a/src/components/molecules/project-card/ProjectCard.module.scss
+++ b/src/components/molecules/project-card/ProjectCard.module.scss
@@ -217,7 +217,7 @@
     border: var(--route-stroke, 1px) solid color-mix(in srgb, var(--accent-color) 50%, transparent);
     color: var(--accent-color);
     border-radius: var(--route-filter-radius, #{$radius-full});
-    padding: $spacing-3xs 6px;
+    padding: $spacing-2xs 6px;
     letter-spacing: $letter-spacing-md;
     line-height: 1.2;
   }
@@ -299,8 +299,8 @@
       color: var(--color-text);
       opacity: 0.7;
       background: var(--color-divider);
-      padding: $spacing-3xs 6px;
-      border-radius: var(--route-card-radius, #{$radius-xs});
+      padding: $spacing-2xs 6px;
+      border-radius: var(--route-card-radius, #{$radius-sm});
       border: var(--route-stroke, 1px) solid var(--color-divider);
 
       @include mobile {

--- a/src/components/organisms/Terminal/SnakeGame.module.scss
+++ b/src/components/organisms/Terminal/SnakeGame.module.scss
@@ -26,7 +26,7 @@
 .hudEsc {
   cursor: pointer;
   border: $border-hairline solid var(--color-divider);
-  border-radius: $radius-xs;
+  border-radius: $radius-sm;
   padding: 1px 6px;
   &:hover { color: var(--color-text); border-color: var(--color-text); }
 }
@@ -65,7 +65,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-3xs;
+  gap: $spacing-2xs;
   margin-top: auto;
   padding-bottom: $spacing-2xs;
 
@@ -77,7 +77,7 @@
 
 .dpadRow {
   display: flex;
-  gap: $spacing-3xs;
+  gap: $spacing-2xs;
 }
 
 .dpadBtn {
@@ -202,7 +202,7 @@
   font-size: $font-size-xs;
 
   th, td {
-    padding: $spacing-3xs $spacing-xs;
+    padding: $spacing-2xs $spacing-xs;
     text-align: left;
     border-bottom: $border-hairline solid var(--color-divider);
   }

--- a/src/components/organisms/Terminal/Terminal.module.scss
+++ b/src/components/organisms/Terminal/Terminal.module.scss
@@ -68,10 +68,10 @@
   padding: $spacing-lg 28px;
 
   background: rgba(var(--color-bg-rgb), 0.98);
-  backdrop-filter: blur($blur-xl);
+  backdrop-filter: blur($blur-md);
   border: var(--route-terminal-border-width, 1px) solid
     var(--route-terminal-border-color, var(--color-divider));
-  border-radius: var(--route-terminal-radius, #{$radius-xl});
+  border-radius: var(--route-terminal-radius, #{$radius-lg});
   box-shadow: var(--route-terminal-shadow);
   display: flex;
   flex-direction: column;
@@ -117,7 +117,7 @@
   }
   &::-webkit-scrollbar-thumb {
     background: var(--color-divider);
-    border-radius: $radius-xs;
+    border-radius: $radius-sm;
 
     &:hover {
       background: var(--color-text);
@@ -352,8 +352,8 @@
     max-width: 95dvw;
     height: 85dvh;
     max-height: none;
-    border-radius: var(--route-terminal-radius-mobile, #{$radius-xl})
-      var(--route-terminal-radius-mobile, #{$radius-xl}) 0 0;
+    border-radius: var(--route-terminal-radius-mobile, #{$radius-lg})
+      var(--route-terminal-radius-mobile, #{$radius-lg}) 0 0;
     padding: $spacing-sm $spacing-md;
     padding-bottom: calc(50px + env(keyboard-inset-height, 12px));
     font-size: $font-size-md;
@@ -477,7 +477,7 @@
 .voiceCountdown {
   height: 2px;
   background: color.adjust($color-white, $alpha: -0.92);
-  border-radius: $radius-xs;
+  border-radius: $radius-sm;
   overflow: hidden;
 }
 
@@ -488,7 +488,7 @@
     color.adjust($color-volta-light, $alpha: -0.1),
     color.adjust($color-lario-dark, $alpha: -0.3)
   );
-  border-radius: $radius-xs;
+  border-radius: $radius-sm;
   animation: voiceCountdown 8s linear forwards;
 }
 

--- a/src/components/organisms/brand-page/BusinessCard.module.scss
+++ b/src/components/organisms/brand-page/BusinessCard.module.scss
@@ -21,7 +21,7 @@
   color: var(--color-accent);
   background: color.adjust($color-volta-light, $alpha: -0.92);
   border: $border-hairline solid color.adjust($color-volta-light, $alpha: -0.8);
-  padding: $spacing-3xs $spacing-xs;
+  padding: $spacing-2xs $spacing-xs;
   border-radius: $radius-sm;
 }
 

--- a/src/components/organisms/fus-ro-dah/FusRoDah.module.scss
+++ b/src/components/organisms/fus-ro-dah/FusRoDah.module.scss
@@ -22,11 +22,11 @@
   gap: $spacing-md;
   background: color.adjust($color-black, $alpha: -0.12);
   border: $border-hairline solid var(--color-accent);
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   padding: $spacing-xl $spacing-xxl;
   pointer-events: all;
-  backdrop-filter: blur($blur-lg);
-  -webkit-backdrop-filter: blur($blur-lg);
+  backdrop-filter: blur($blur-md);
+  -webkit-backdrop-filter: blur($blur-md);
   animation: panelIn 0.25s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -37,8 +37,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: $spacing-3xl;
-  height: $spacing-3xl;
+  width: $spacing-2xl;
+  height: $spacing-2xl;
 }
 
 .micPulse {
@@ -69,7 +69,7 @@
   width: 200px;
   height: 3px;
   background: color.adjust($color-white, $alpha: -0.88);
-  border-radius: $radius-xs;
+  border-radius: $radius-sm;
   overflow: hidden;
 }
 
@@ -78,7 +78,7 @@
 .countdownFill {
   height: 100%;
   background: var(--color-accent);
-  border-radius: $radius-xs;
+  border-radius: $radius-sm;
   animation: countdown 8s linear forwards;
 }
 

--- a/src/components/templates/Layout/MobileNav.tsx
+++ b/src/components/templates/Layout/MobileNav.tsx
@@ -16,13 +16,16 @@ import styles from "./layout.module.scss";
 export default function MobileNav() {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
+  const [lastPathname, setLastPathname] = useState(pathname);
+
+  // Close the overlay on route change by adjusting state during render
+  // (React's recommended pattern) rather than a cascading setState-in-effect.
+  if (pathname !== lastPathname) {
+    setLastPathname(pathname);
+    setIsOpen(false);
+  }
 
   const close = () => setIsOpen(false);
-
-  // Close on route change
-  useEffect(() => {
-    setIsOpen(false);
-  }, [pathname]);
 
   // Lock body scroll while the overlay is open
   useEffect(() => {

--- a/src/components/templates/Layout/layout.module.scss
+++ b/src/components/templates/Layout/layout.module.scss
@@ -118,7 +118,7 @@
 
   &::-webkit-scrollbar-thumb {
     background: var(--color-surface-glass);
-    border-radius: $radius-xs;
+    border-radius: $radius-sm;
   }
 }
 
@@ -179,7 +179,7 @@
 .terminalLink {
   background: rgba(var(--color-bg-rgb), 0.82);
   border: $border-base solid color-mix(in srgb, var(--color-text) 30%, transparent);
-  border-radius: var(--route-card-radius, #{$radius-xl});
+  border-radius: var(--route-card-radius, #{$radius-lg});
   padding: $spacing-sm $spacing-md;
   min-height: $touch-target-min;
   cursor: pointer;
@@ -219,11 +219,11 @@
 .themePill {
   width: $spacing-xl;
   height: $spacing-md;
-  border-radius: $radius-xl;
+  border-radius: $radius-lg;
   border: $border-hairline solid var(--color-divider);
   display: flex;
   align-items: center;
-  padding: 0 $spacing-3xs;
+  padding: 0 $spacing-2xs;
   justify-content: flex-start;
 
   &[data-dark="true"] {
@@ -354,14 +354,17 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: $spacing-3xs;
+  gap: $spacing-2xs;
   width: $touch-target-min;
   height: $touch-target-min;
   padding: $spacing-xs;
   background: rgba(var(--color-bg-rgb), 0.9);
   border: $border-base solid var(--color-text);
-  border-radius: var(--route-card-radius, #{$radius-xl});
+  border-radius: var(--route-card-radius, #{$radius-lg});
   cursor: pointer;
+  // Match the carved wobble of the other chrome (rails/overlay); the Terminal
+  // stays glass so it deliberately keeps a crisp, un-inked edge.
+  filter: var(--ink-fine);
 
   span {
     display: block;
@@ -375,13 +378,13 @@
   }
 
   &.burgerOpen span:nth-child(1) {
-    transform: translateY(calc(#{$spacing-3xs} + #{$border-base})) rotate(45deg);
+    transform: translateY(calc(#{$spacing-2xs} + #{$border-base})) rotate(45deg);
   }
   &.burgerOpen span:nth-child(2) {
     opacity: 0;
   }
   &.burgerOpen span:nth-child(3) {
-    transform: translateY(calc(-1 * (#{$spacing-3xs} + #{$border-base}))) rotate(-45deg);
+    transform: translateY(calc(-1 * (#{$spacing-2xs} + #{$border-base}))) rotate(-45deg);
   }
 
   @include mobile {
@@ -397,8 +400,8 @@
   display: flex;
   flex-direction: column;
   background: rgba(var(--color-bg-rgb), 0.92);
-  backdrop-filter: blur($blur-2xl);
-  -webkit-backdrop-filter: blur($blur-2xl);
+  backdrop-filter: blur($blur-md);
+  -webkit-backdrop-filter: blur($blur-md);
   overflow-y: auto;
   filter: var(--ink-fine);
   padding: $spacing-md $spacing-xl $spacing-2xl;

--- a/src/stories/tokens/DesignTokens.mdx
+++ b/src/stories/tokens/DesignTokens.mdx
@@ -123,7 +123,7 @@ for all new work.
 
 ## Spacing
 
-Base unit: **4px**. Scale: 4, 8, 12, 16, 24, 32, 48, 56, 80px.
+Base unit: **4px**. Scale: 4, 8, 12, 16, 24, 32, 48, 80px.
 
 | Token | Value | Example |
 |---|---|---|
@@ -134,6 +134,7 @@ Base unit: **4px**. Scale: 4, 8, 12, 16, 24, 32, 48, 56, 80px.
 | `$spacing-lg` | 24px | Section gaps |
 | `$spacing-xl` | 32px | Large sections |
 | `$spacing-2xl` | 48px | Page sections |
+| `$spacing-xxl` | 80px | Hero spacing |
 
 ---
 
@@ -143,8 +144,7 @@ Base unit: **4px**. Scale: 4, 8, 12, 16, 24, 32, 48, 56, 80px.
 |---|---|---|
 | `$radius-sm` | 4px | Buttons, inputs |
 | `$radius-md` | 8px | Cards |
-| `$radius-lg` | 12px | Modals |
-| `$radius-xl` | 16px | Large containers |
+| `$radius-lg` | 16px | Modals, large containers |
 | `$radius-full` | 999px | Pills, avatars |
 
 ---

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -150,8 +150,8 @@ $font-size-h4-fluid: clamp(1.125rem, 0.75rem + 1.25vw, 1.5625rem);
 $font-size-h5-fluid: clamp(1rem, 0.75rem + 1vw, 1.25rem);
 $font-size-h6-fluid: clamp(0.875rem, 0.625rem + 1vw, 1.125rem);
 
-// Spacing Scale (base unit 4px)
-$spacing-3xs: 2px;
+// Spacing Scale — 8 steps on a 4px grid (2px hair and 56px removed:
+// merged into 4px and 48px to keep one intentional, uniform scale)
 $spacing-2xs: 4px;
 $spacing-xs: 8px;
 $spacing-sm: 12px;
@@ -159,7 +159,6 @@ $spacing-md: 16px;
 $spacing-lg: 24px;
 $spacing-xl: 32px;
 $spacing-2xl: 48px;
-$spacing-3xl: 56px;
 $spacing-xxl: 80px;
 
 // Touch targets (minimum 44px per WCAG)
@@ -174,20 +173,15 @@ $size-scrollbar: 6px;     // custom scrollbar thickness
 $border-hairline: 1px;
 $border-base: 2px;
 
-// Backdrop blur scale (values mirror real usage across the app)
-$blur-xs: 4px;
+// Backdrop blur scale — 3 intentional steps
 $blur-sm: 8px;
-$blur-md: 12px;
-$blur-lg: 16px;
-$blur-xl: 20px;
-$blur-2xl: 24px;
+$blur-md: 16px;
+$blur-lg: 24px;
 
-// Border Radius
-$radius-xs: 2px;
+// Border Radius — 3 steps + full
 $radius-sm: 4px;
 $radius-md: 8px;
-$radius-lg: 12px;
-$radius-xl: 16px;
+$radius-lg: 16px;
 $radius-full: 999px;
 
 // Breakpoints (mobile-first)


### PR DESCRIPTION
## Cosa

Riduce le scale di utility a insiemi piccoli e intenzionali (**niente hardcoded** — stessi token, meno nomi). Ogni valore rimosso è stato accorpato al più vicino tra quelli tenuti, così lo scostamento visivo è minimo.

### Token
- **Radius 6 → 3 + full**: sm=4, md=8, lg=16, full. (xs→sm, xl→lg, lg 12→16)
- **Blur 6 → 3**: sm=8, md=16, lg=24.
- **Spacing 10 → 8**: tolti i due valori sfusi (2px e 56px), accorpati a 4px e 48px.

Le scale **tipografiche** (font-size/letter-spacing/line-height) sono lasciate intatte: sono un sistema di tipo progettato, non entropia arbitraria.

### Bordi / ink
- Il **burger mobile** ora ha lo stesso wobble carved delle altre chrome (rail/overlay).
- Il **Terminal resta vetro** (backdrop-blur), incompatibile con un filtro su un antenato → bordo netto per scelta.

Docs `DesignTokens.mdx` aggiornate. Build + 136 test verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)