### PR TITLE
refactor: flatten typography tracking and micro-size scales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ public/storybook/
 
 # local dev docs (design notes, tasks, open points — not for repo)
 /_dev/
+/docs/brand-kit.md

--- a/src/app/about/page.module.scss
+++ b/src/app/about/page.module.scss
@@ -54,7 +54,7 @@
   display: block;
   font-size: clamp(1rem, 3.5vw, 2rem);
   font-weight: 700;
-  letter-spacing: $letter-spacing-base;
+  letter-spacing: $letter-spacing-sm;
   line-height: 1.2;
   text-transform: uppercase;
   color: var(--color-text);
@@ -88,7 +88,7 @@
 
 .metaLabel {
   font-size: $font-size-xs;
-  letter-spacing: $letter-spacing-xxl;
+  letter-spacing: $letter-spacing-xl;
   text-transform: uppercase;
   opacity: 0.4;
   font-weight: 700;
@@ -97,14 +97,14 @@
 .metaValue {
   font-size: $font-size-sm;
   font-weight: 700;
-  letter-spacing: $letter-spacing-base;
+  letter-spacing: $letter-spacing-sm;
   text-transform: uppercase;
 }
 
 .metaValueAccent {
   font-size: $font-size-sm;
   font-weight: 700;
-  letter-spacing: $letter-spacing-base;
+  letter-spacing: $letter-spacing-sm;
   text-transform: uppercase;
   color: var(--color-accent);
 }
@@ -243,7 +243,7 @@
 .interestName {
   font-size: $font-size-base;
   font-weight: 700;
-  letter-spacing: $letter-spacing-base;
+  letter-spacing: $letter-spacing-sm;
   text-transform: uppercase;
 }
 
@@ -286,7 +286,7 @@
   font-size: $font-size-xs;
   font-weight: 700;
   line-height: 1.4;
-  letter-spacing: $letter-spacing-xxl;
+  letter-spacing: $letter-spacing-xl;
   text-transform: uppercase;
   opacity: 0.45;
   text-align: center;

--- a/src/app/lab/[slug]/ProjectDetail.module.scss
+++ b/src/app/lab/[slug]/ProjectDetail.module.scss
@@ -52,7 +52,7 @@
   font-family: $font-family-mono;
   font-size: $font-size-xs;
   text-transform: uppercase;
-  letter-spacing: $letter-spacing-xxl;
+  letter-spacing: $letter-spacing-xl;
   border: $border-hairline solid var(--color-divider);
   border-radius: var(--route-filter-radius, #{$radius-full});
   padding: 0.2rem 0.6rem;

--- a/src/app/lab/page.module.scss
+++ b/src/app/lab/page.module.scss
@@ -60,7 +60,7 @@
   font-family: $font-family-mono;
   font-size: $font-size-xs;
   text-transform: uppercase;
-  letter-spacing: $letter-spacing-xxl;
+  letter-spacing: $letter-spacing-xl;
   color: var(--color-text);
   opacity: 0.35;
   white-space: nowrap;
@@ -236,7 +236,7 @@
   font-family: $font-family-mono;
   font-size: $font-size-xs;
   text-transform: uppercase;
-  letter-spacing: $letter-spacing-xxl;
+  letter-spacing: $letter-spacing-xl;
   color: var(--color-text);
   opacity: 0.35;
   transition: color 0.15s ease;

--- a/src/components/organisms/Terminal/Terminal.module.scss
+++ b/src/components/organisms/Terminal/Terminal.module.scss
@@ -155,7 +155,7 @@
   text-align: center;
 
   @include bp-down($breakpoint-md) {
-    font-size: $font-size-3xs;
+    font-size: $font-size-2xs;
     letter-spacing: -0.1em;
     max-height: 40vh;
   }

--- a/src/components/templates/Layout/layout.module.scss
+++ b/src/components/templates/Layout/layout.module.scss
@@ -328,7 +328,7 @@
   font-family: $font-family-mono;
   font-size: $font-size-xs;
   font-weight: 700;
-  letter-spacing: $letter-spacing-xxl;
+  letter-spacing: $letter-spacing-xl;
   text-transform: uppercase;
   text-decoration: none;
   color: var(--color-text);

--- a/src/stories/tokens/DesignTokens.mdx
+++ b/src/stories/tokens/DesignTokens.mdx
@@ -114,7 +114,7 @@ Or use the dynamic `heading()` mixin:
 
 ### Deprecated Numeric Tokens
 
-The old `$font-size-*` tokens (3xs through 2xl) remain available for
+The old `$font-size-*` tokens (2xs through 4xl) remain available for
 terminal, micro-text, and special use cases but are **not** part of the
 canonical type scale. Use the semantic tokens (h1–h6, body, small, label)
 for all new work.

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -89,20 +89,18 @@ $font-family-display: var(--font-josefin-slab), serif;
 $font-family-primary: var(--font-josefin-sans), sans-serif;
 $font-family-mono: var(--font-geist-mono), monospace;
 
-// Type Scale — Numeric (backward-compatible, for terminal/micro/special use)
-$font-size-3xs: 0.375rem; // 6px
-$font-size-2xs: 0.5rem;   // 8px
-$font-size-xs: 0.625rem; // 10px
-$font-size-sm: 0.75rem;  // 12px
-
+// Type Scale — Numeric (terminal/micro/display use; body copy uses the
+// semantic scale below). 6px step removed: merged into 2xs.
+$font-size-2xs: 0.5rem;    // 8px
+$font-size-xs: 0.625rem;   // 10px
+$font-size-sm: 0.75rem;    // 12px
 $font-size-base: 0.875rem; // 14px
-$font-size-md: 1rem;     // 16px
-$font-size-lg: 1.5rem;   // 24px
-$font-size-xl: 2rem;     // 32px
-
-$font-size-3xl: 3rem;    // 48px
-$font-size-4xl: 4rem;    // 64px
-$font-size-2xl: 2.5rem;  // 40px (alias for xxl)
+$font-size-md: 1rem;       // 16px
+$font-size-lg: 1.5rem;     // 24px
+$font-size-xl: 2rem;       // 32px
+$font-size-2xl: 2.5rem;    // 40px
+$font-size-3xl: 3rem;      // 48px
+$font-size-4xl: 4rem;      // 64px
 
 // Type Scale — Semantic (PDF spec: Typefaces Details.pdf)
 // Headings use Josefin Slab for display (h1) and Josefin Sans (h2–h6)
@@ -131,14 +129,14 @@ $letter-spacing-h6: 0.014em;
 $letter-spacing-body: 0.016em;
 $letter-spacing-small: 0.036em;
 $letter-spacing-label: 0.042em;
+// Numeric tracking scale — 7 intentional steps (0.06em merged into sm,
+// 0.14em merged into xl: the removed values were visually indistinguishable)
 $letter-spacing-tightest: -0.05em;
 $letter-spacing-tighter: -0.02em;
 $letter-spacing-sm: 0.05em;
-$letter-spacing-base: 0.06em;
 $letter-spacing-md: 0.08em;
 $letter-spacing-lg: 0.1em;
 $letter-spacing-xl: 0.12em;
-$letter-spacing-xxl: 0.14em;
 $letter-spacing-wide: 0.2em;
 
 // Fluid Type Scale — responsive clamp() values for headings


### PR DESCRIPTION
Second pass of the token consolidation, same spirit as #8: small intentional scales, nothing hardcoded, negligible visual shift.

## Removed tokens (remapped to nearest kept value)

| Removed | Value | Remapped to | Value | Uses |
|---|---|---|---|---|
| $font-size-3xs | 6px | $font-size-2xs | 8px | 1 (Terminal micro text) |
| $letter-spacing-base | 0.06em | $letter-spacing-sm | 0.05em | 4 (About) |
| $letter-spacing-xxl | 0.14em | $letter-spacing-xl | 0.12em | 6 (Lab, ProjectDetail, footer socials) |

## Untouched by design

The semantic type scale (h1-h6, body, small, label: sizes, line-heights, trackings from the Typefaces Details PDF spec) and the fluid clamp scale are a designed system, not entropy. Numeric font sizes 2xs-4xl are all in real use (min 2 refs each).

Result: tracking scale 9 -> 7 steps, numeric type scale 11 -> 10 steps. Lint, build and 136 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)