### PR TITLE
fix: lab scroll perf, discoverable rails, squircle rows on design tokens

### DIFF
--- a/src/app/about/page.module.scss
+++ b/src/app/about/page.module.scss
@@ -15,6 +15,8 @@
   border-top: $border-hairline solid var(--color-divider);
   position: relative;
   z-index: 10;
+  // Carved wobble on the in-flow page root (see layout.module.scss .main)
+  filter: var(--ink);
 }
 
 // ── Hero ──────────────────────────────────────────────────────────────────────

--- a/src/app/lab/[slug]/ProjectDetail.module.scss
+++ b/src/app/lab/[slug]/ProjectDetail.module.scss
@@ -3,15 +3,17 @@
 
 .container {
   min-height: 100vh;
-  padding: 5.5rem 1rem 6rem;
+  padding: $spacing-xxl $spacing-md $spacing-xxl;
   max-width: 860px;
   margin: 0 auto;
   position: relative;
   z-index: 10;
   color: var(--color-text);
+  // Carved wobble on the in-flow page root (see layout.module.scss .main)
+  filter: var(--ink);
 
   @include bp-up($breakpoint-xl) {
-    padding: 7rem 2rem 6rem;
+    padding: $spacing-xxl $spacing-xl;
   }
 }
 
@@ -19,7 +21,7 @@
 .backLink {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: $spacing-xs;
   font-family: $font-family-mono;
   font-size: $font-size-xs;
   text-transform: uppercase;
@@ -27,7 +29,7 @@
   color: var(--color-text);
   opacity: 0.45;
   text-decoration: none;
-  margin-bottom: 3rem;
+  margin-bottom: $spacing-2xl;
   transition: opacity 0.15s ease;
 
   &:hover { opacity: 1; }
@@ -36,15 +38,15 @@
 // ── Header ────────────────────────────────────────────────────────────────────
 .header {
   border-bottom: $border-base solid var(--color-text);
-  padding-bottom: 2rem;
-  margin-bottom: 3rem;
+  padding-bottom: $spacing-xl;
+  margin-bottom: $spacing-2xl;
 }
 
 .meta {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 1.25rem;
+  gap: $spacing-xs;
+  margin-bottom: $spacing-lg;
   flex-wrap: wrap;
 }
 
@@ -55,7 +57,7 @@
   letter-spacing: $letter-spacing-xl;
   border: $border-hairline solid var(--color-divider);
   border-radius: var(--route-filter-radius, #{$radius-full});
-  padding: 0.2rem 0.6rem;
+  padding: $spacing-2xs $spacing-xs;
   color: var(--color-text);
   opacity: 0.7;
 }
@@ -83,7 +85,7 @@
   color: var(--color-accent);
   border: $border-hairline solid color-mix(in srgb, var(--color-accent) 40%, transparent);
   border-radius: var(--route-filter-radius, #{$radius-full});
-  padding: 0.2rem 0.55rem;
+  padding: $spacing-2xs $spacing-xs;
 }
 
 .title {
@@ -91,9 +93,9 @@
   font-weight: 800;
   font-size: clamp(2.25rem, 7vw, 4.5rem);
   line-height: 0.92;
-  letter-spacing: -0.04em;
+  letter-spacing: $letter-spacing-tightest;
   text-transform: uppercase;
-  margin: 0 0 1.25rem;
+  margin: 0 0 $spacing-lg;
   color: var(--color-text);
 }
 
@@ -112,14 +114,14 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  margin-bottom: 3.5rem;
+  margin-bottom: $spacing-2xl;
 }
 
 .act {
   display: grid;
-  grid-template-columns: 3.5rem 1fr;
-  gap: 1.5rem;
-  padding: 2rem 0;
+  grid-template-columns: $spacing-2xl 1fr;
+  gap: $spacing-lg;
+  padding: $spacing-xl 0;
   border-bottom: $border-hairline solid var(--color-divider);
 
   &:first-child {
@@ -127,9 +129,9 @@
   }
 
   @include mobile {
-    grid-template-columns: 2.25rem 1fr;
-    gap: 1rem;
-    padding: 1.5rem 0;
+    grid-template-columns: $spacing-xl 1fr;
+    gap: $spacing-md;
+    padding: $spacing-lg 0;
   }
 }
 
@@ -139,14 +141,14 @@
   letter-spacing: $letter-spacing-lg;
   color: var(--color-text);
   opacity: 0.25;
-  padding-top: 0.3rem;
+  padding-top: $spacing-2xs;
   flex-shrink: 0;
 }
 
 .actBody {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: $spacing-sm;
 }
 
 .actTitle {
@@ -154,7 +156,7 @@
   font-weight: 700;
   font-size: $font-size-xs;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
+  letter-spacing: $letter-spacing-wide;
   color: var(--color-text);
   opacity: 0.45;
   margin: 0;
@@ -172,13 +174,13 @@
 
 // ── Media ─────────────────────────────────────────────────────────────────────
 .media {
-  margin-bottom: 3.5rem;
+  margin-bottom: $spacing-2xl;
   border: $border-base solid var(--color-text);
   border-radius: $radius-md;
   overflow: hidden;
   display: grid;
   grid-template-columns: 1fr;
-  gap: 2px;
+  gap: $border-base;
   background: var(--color-text);
 }
 
@@ -216,16 +218,16 @@
 // ── Footer ────────────────────────────────────────────────────────────────────
 .footer {
   border-top: $border-base solid var(--color-text);
-  padding-top: 2rem;
+  padding-top: $spacing-xl;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: $spacing-lg;
 }
 
 .stack {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: $spacing-xs;
 }
 
 .stackTag {
@@ -237,20 +239,20 @@
   opacity: 0.5;
   border: $border-hairline solid var(--color-divider);
   border-radius: var(--route-filter-radius, #{$radius-full});
-  padding: 0.2rem 0.6rem;
+  padding: $spacing-2xs $spacing-xs;
 }
 
 .links {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.75rem;
+  gap: $spacing-sm;
 }
 
 .primaryLink {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: $spacing-xs;
   background: var(--color-text);
   color: var(--color-bg);
   font-family: $font-family-primary;
@@ -259,7 +261,7 @@
   text-transform: uppercase;
   letter-spacing: $letter-spacing-xl;
   text-decoration: none;
-  padding: 0.65rem 1.25rem;
+  padding: $spacing-sm $spacing-lg;
   border-radius: var(--route-card-radius, #{$radius-lg});
   border: $border-base solid var(--color-text);
   box-shadow: var(--depth-sm);
@@ -267,7 +269,7 @@
 
   &:hover {
     box-shadow: var(--depth-md, none);
-    transform: translate(-2px, -2px);
+    transform: var(--route-card-hover-transform, translate(-2px, -2px));
     opacity: 0.9;
   }
 }
@@ -275,7 +277,7 @@
 .secondaryLink {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: $spacing-2xs;
   font-family: $font-family-mono;
   font-size: $font-size-xs;
   text-transform: uppercase;
@@ -283,7 +285,7 @@
   color: var(--color-text);
   opacity: 0.5;
   text-decoration: none;
-  padding: 0.65rem 0;
+  padding: $spacing-sm 0;
   transition: opacity 0.15s ease;
 
   &:hover { opacity: 1; }

--- a/src/app/lab/page.module.scss
+++ b/src/app/lab/page.module.scss
@@ -125,6 +125,8 @@
 .projectList {
   display: flex;
   flex-direction: column;
+  gap: $spacing-sm;
+  padding-top: $spacing-sm;
   border-top: $border-base solid var(--color-text);
 }
 
@@ -316,6 +318,9 @@
 .archiveList {
   overflow: hidden;
   margin-top: $spacing-md;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
 }
 
 .archivedRow {

--- a/src/app/lab/page.module.scss
+++ b/src/app/lab/page.module.scss
@@ -4,12 +4,16 @@
 // ── Container ─────────────────────────────────────────────────────────────────
 .container {
   min-height: 100vh;
-  padding: 5.5rem 1rem 6rem;
+  padding: $spacing-xxl $spacing-md $spacing-xxl;
   position: relative;
   z-index: 10;
+  // Carved wobble on the in-flow page root (not the scrollport) so the
+  // filtered layer is cached and translated during scroll instead of
+  // being re-filtered every frame.
+  filter: var(--ink);
 
   @include bp-up($breakpoint-xl) {
-    padding: 6rem 60px 6rem;
+    padding: $spacing-xxl $spacing-2xl;
     max-width: 1400px;
     margin: 0 auto;
   }
@@ -17,9 +21,9 @@
 
 // ── Header ────────────────────────────────────────────────────────────────────
 .header {
-  margin-bottom: 2rem;
+  margin-bottom: $spacing-xl;
   border-bottom: $border-base solid var(--color-text);
-  padding-bottom: 1.5rem;
+  padding-bottom: $spacing-lg;
 }
 
 .pageTitle {
@@ -27,7 +31,7 @@
   font-weight: 800;
   line-height: 0.88;
   letter-spacing: $letter-spacing-tightest;
-  margin: 0 0 0.75rem;
+  margin: 0 0 $spacing-sm;
   color: var(--color-text);
   text-transform: uppercase;
   transform-origin: top center;
@@ -38,7 +42,7 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 1rem;
+  gap: $spacing-md;
   flex-wrap: wrap;
 }
 
@@ -69,14 +73,14 @@
 // ── Filters ───────────────────────────────────────────────────────────────────
 .filters {
   display: flex;
-  gap: 0.4rem;
-  margin-bottom: 2.5rem;
+  gap: $spacing-xs;
+  margin-bottom: $spacing-xl;
   flex-wrap: wrap;
 
   @include mobile {
     overflow-x: auto;
     flex-wrap: nowrap;
-    padding-bottom: 0.25rem;
+    padding-bottom: $spacing-2xs;
     scrollbar-width: none;
 
     &::-webkit-scrollbar { display: none; }
@@ -93,7 +97,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: $letter-spacing-xl;
-  padding: 0.4rem 1rem;
+  padding: $spacing-xs $spacing-md;
   border-radius: var(--route-filter-radius, #{$radius-md});
   cursor: pointer;
   transition:
@@ -127,10 +131,13 @@
 .projectRow {
   all: unset;
   display: grid;
-  grid-template-columns: 3rem 1fr auto;
+  grid-template-columns: $spacing-2xl 1fr auto;
   align-items: center;
-  gap: 1.5rem;
-  padding: 1.75rem 0.5rem;
+  gap: $spacing-lg;
+  padding: $spacing-lg $spacing-xs;
+  // Squircle from the design system so the inverted hover block never shows
+  // 90-degree corners; the hairline below stays as the list separator.
+  border-radius: var(--route-card-radius, #{$radius-lg});
   border-bottom: $border-hairline solid color-mix(in srgb, var(--color-text) 20%, transparent);
   cursor: pointer;
   transition:
@@ -142,8 +149,8 @@
 
   &:hover {
     background: var(--color-text);
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-left: $spacing-md;
+    padding-right: $spacing-md;
     border-color: var(--color-text);
 
     .rowNum,
@@ -164,13 +171,13 @@
   }
 
   @include mobile {
-    grid-template-columns: 2.25rem 1fr auto;
-    gap: 0.75rem;
-    padding: 1rem 0.25rem;
+    grid-template-columns: $spacing-xl 1fr auto;
+    gap: $spacing-sm;
+    padding: $spacing-md $spacing-2xs;
 
     &:hover {
-      padding-left: 0.75rem;
-      padding-right: 0.75rem;
+      padding-left: $spacing-sm;
+      padding-right: $spacing-sm;
     }
   }
 }
@@ -183,22 +190,22 @@
   opacity: 0.3;
   flex-shrink: 0;
   align-self: start;
-  padding-top: 0.2rem;
+  padding-top: $spacing-2xs;
   transition: color 0.15s ease;
 }
 
 .rowMain {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: $spacing-2xs;
   min-width: 0;
 }
 
 .rowTitle {
   font-family: $font-family-primary;
   font-weight: 700;
-  font-size: clamp(1rem, 2vw, 1.25rem);
-  letter-spacing: -0.01em;
+  font-size: clamp(#{$font-size-md}, 2vw, 1.25rem);
+  letter-spacing: $letter-spacing-h1;
   color: var(--color-text);
   line-height: 1.1;
   text-transform: uppercase;
@@ -228,7 +235,7 @@
 .rowMeta {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: $spacing-sm;
   flex-shrink: 0;
 }
 
@@ -267,21 +274,21 @@
   font-size: $font-size-base;
   color: var(--color-text);
   opacity: 0.4;
-  padding: 3rem 0;
+  padding: $spacing-2xl 0;
   text-align: center;
 }
 
 // ── Archive ───────────────────────────────────────────────────────────────────
 .archive {
   border-top: $border-hairline solid color-mix(in srgb, var(--color-text) 20%, transparent);
-  padding-top: 2rem;
-  margin-top: 2rem;
+  padding-top: $spacing-xl;
+  margin-top: $spacing-xl;
 }
 
 .archiveToggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: $spacing-xs;
   background: transparent;
   border: none;
   color: var(--color-text);
@@ -291,7 +298,7 @@
   text-transform: uppercase;
   letter-spacing: $letter-spacing-lg;
   cursor: pointer;
-  padding: 0.5rem 0;
+  padding: $spacing-xs 0;
   transition: opacity 0.15s ease;
   min-height: $touch-target-min;
 
@@ -301,14 +308,14 @@
 .archiveCount {
   background: var(--color-divider);
   border-radius: var(--route-filter-radius, #{$radius-full});
-  padding: 0.1rem 0.5rem;
+  padding: 0 $spacing-xs;
   font-size: $font-size-xs;
   opacity: 0.9;
 }
 
 .archiveList {
   overflow: hidden;
-  margin-top: 1rem;
+  margin-top: $spacing-md;
 }
 
 .archivedRow {

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -19,6 +19,9 @@
   z-index: 100;
   width: max-content;
   max-width: min(520px, calc(100vw - 2.5rem));
+  // Ink on the hero only: filtering .shell would pull the 60fps particle
+  // canvas under the displacement filter and re-filter every frame.
+  filter: var(--ink);
 
   @include mobile {
     bottom: $spacing-2xl;
@@ -78,6 +81,7 @@
   z-index: 100;
   opacity: 0.45;
   transition: opacity 0.3s ease;
+  filter: var(--ink-fine);
 
   &:hover {
     opacity: 1;

--- a/src/app/secrets/page.module.scss
+++ b/src/app/secrets/page.module.scss
@@ -10,6 +10,8 @@
   color: $effect-terminal-green;
   padding: $spacing-md;
   box-sizing: border-box;
+  // Carved wobble on the in-flow page root (see layout.module.scss .main)
+  filter: var(--ink);
 }
 
 .terminal {

--- a/src/components/organisms/Background/GlobalBackground.tsx
+++ b/src/components/organisms/Background/GlobalBackground.tsx
@@ -11,7 +11,10 @@ import styles from './GlobalBackground.module.scss';
 export default function GlobalBackground() {
   return (
     <div className={styles.container}>
-      <Canvas dpr={[1, 1.5]}>
+      {/* frameloop="demand": the scene is static apart from the mouse-driven
+          lift, so ThreeBackground invalidates on pointer moves instead of
+          re-rendering every frame behind the page content. */}
+      <Canvas dpr={[1, 1.5]} frameloop="demand">
         <ambientLight intensity={0.5} />
         <Suspense fallback={null}>
           <ThreeBackground />

--- a/src/components/organisms/Background/ThreeBackground.tsx
+++ b/src/components/organisms/Background/ThreeBackground.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo, useRef, useEffect } from 'react';
-import { useLoader, useFrame, extend } from '@react-three/fiber';
+import { useLoader, useFrame, extend, useThree } from '@react-three/fiber';
 import { SVGLoader } from 'three/examples/jsm/loaders/SVGLoader.js';
 import * as THREE from 'three';
 import { shaderMaterial } from '@react-three/drei';
@@ -97,6 +97,7 @@ declare global {
  */
 export default function ThreeBackground() {
   const svgData = useLoader(SVGLoader, '/background.svg');
+  const invalidate = useThree((state) => state.invalidate);
   
   // Create material once using useMemo instead of useRef to be safe for rendering
   const material = useMemo(() => new HoverMaterial({
@@ -126,12 +127,14 @@ export default function ThreeBackground() {
         const x = (event.clientX / window.innerWidth) * 2 - 1;
         const y = -(event.clientY / window.innerHeight) * 2 + 1;
         mouseRef.current.set(x, y);
+        // Canvas runs frameloop="demand": request a frame for the hover lift
+        invalidate();
       };
 
       window.addEventListener('mousemove', handleMouseMove);
       return () => window.removeEventListener('mousemove', handleMouseMove);
     }
-  }, []);
+  }, [invalidate]);
 
   // Performance: Merge all geometries into one single mesh
   const mergedGeometry = useMemo(() => {
@@ -211,7 +214,10 @@ export default function ThreeBackground() {
             // Lerp for smoothness (optional, makes interaction feel heavier/classier)
             const currentMouse = shaderRef.current.uniforms.uMouse.value;
             // Lerp towards the new position
-            currentMouse.lerp(localPoint, 0.15); 
+            currentMouse.lerp(localPoint, 0.15);
+
+            // Keep requesting frames until the lerp settles, then go idle
+            if (currentMouse.distanceTo(localPoint) > 0.5) invalidate();
         }
     }
   });

--- a/src/components/templates/Layout/layout.module.scss
+++ b/src/components/templates/Layout/layout.module.scss
@@ -51,13 +51,16 @@
   align-items: flex-end;
 }
 
+// Auto-hidden rails keep a visible scribed line on their inner edge so the
+// navigation stays discoverable, and a wider peek strip as the hover target.
 .leftColumn {
   left: 0;
   align-items: flex-start;
 
   &.autoHide {
-    transform: translateX(calc(-100% + 20px));
+    transform: translateX(calc(-100% + var(--chrome-rail-peek)));
     pointer-events: auto; // Needs to be interactive to hover back
+    border-right: var(--route-chrome-border-width, 0px) var(--route-divider-style, solid) var(--route-chrome-border-color, transparent);
 
     &:hover {
       transform: translateX(0);
@@ -75,8 +78,9 @@
   align-items: flex-end;
 
   &.autoHide {
-    transform: translateX(calc(100% - 20px));
+    transform: translateX(calc(100% - var(--chrome-rail-peek)));
     pointer-events: auto;
+    border-left: var(--route-chrome-border-width, 0px) var(--route-divider-style, solid) var(--route-chrome-border-color, transparent);
 
     &:hover {
       transform: translateX(0);
@@ -105,7 +109,10 @@
   overflow-y: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
-  filter: var(--ink);
+  // No filter here: an SVG displacement filter on the scrollport forces a
+  // full-viewport re-filter on every scroll frame (the /lab lag). Each page
+  // applies var(--ink) to its own in-flow content root instead, so the
+  // filtered layer is cached and simply translated while scrolling.
 
   // Custom Scrollbar
   &::-webkit-scrollbar {

--- a/src/styles/adaptive.scss
+++ b/src/styles/adaptive.scss
@@ -37,6 +37,7 @@
   --route-nav-link-weight: 700;
   --chrome-rail-width: 328px; // desktop side-rail width
   --chrome-rail-pad-x: 40px; // desktop side-rail horizontal padding
+  --chrome-rail-peek: 32px; // visible sliver of an auto-hidden rail (hover target)
 
   // ── Cards ────────────────────────────────────────────────────────────────────
   --route-card-shadow: var(--depth-sm);


### PR DESCRIPTION
Fixes the three issues reported on the live site.

## 1. /work (lab) lag

Two compounding causes, both structural:

- The ink displacement filter (feTurbulence + feDisplacementMap) sat on the .main **scrollport**, forcing a full-viewport re-filter on every scroll frame. It now sits on each page's **in-flow content root**, so the filtered layer is rasterized once and simply translated while scrolling. Same wobble, none of the per-frame cost. The home hero is inked separately so the 60fps particle canvas never renders under the filter; time-machine and the demo pages (fixed elements + live canvas) stay crisp on purpose.
- The global three.js background rendered and raycast **every frame** behind the content. It now runs frameloop="demand": frames are requested only while the pointer moves or the hover lift is settling.

## 2. Navigation discoverability on /lab and /about

- The auto-hidden rails now keep a scribed 2px line on their inner edge: the two vertical lines stay visible at both sides of the viewport, so the nav reads as present.
- The peek/hover strip grows from a raw 20px to a --chrome-rail-peek token (32px), making the reveal easier to trigger.

## 3. Squircle + design system in projects

- Project rows take the route squircle radius (16px): the inverted hover block no longer shows 90-degree corners.
- Full token sweep of lab list + project detail: every raw rem/px spacing, tracking and hover transform mapped to the nearest scale token. Display clamp() sizes and layout max-widths are intentionally left as typography/layout design.

Note: ProjectCard (the tilt/spotlight card) is no longer rendered anywhere in the app, only in Storybook; it kept its square corner accents and is a candidate for deletion in a follow-up.

Lint, build and 136 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)