### PR TITLE
feat: honor prefers-reduced-motion across the whole experience

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import MainLayout, { SiteChrome } from "@/components/templates/Layout";
+import MotionProvider from "@/components/atoms/motion-provider";
 import FusRoDahWrapper from "@/components/organisms/fus-ro-dah";
 import { socials } from "@/data/nav";
 import InkFilters from "@/components/atoms/ink-filters/InkFilters";
@@ -150,17 +151,19 @@ export default function RootLayout({
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
         />
-        <ThemeProvider>
-          <AudioProvider>
-            <VoiceShoutProvider>
-              <InkFilters />
-              <RouteTracker />
-              <SiteChrome />
-              <MainLayout>{children}</MainLayout>
-              <FusRoDahWrapper />
-            </VoiceShoutProvider>
-          </AudioProvider>
-        </ThemeProvider>
+        <MotionProvider>
+          <ThemeProvider>
+            <AudioProvider>
+              <VoiceShoutProvider>
+                <InkFilters />
+                <RouteTracker />
+                <SiteChrome />
+                <MainLayout>{children}</MainLayout>
+                <FusRoDahWrapper />
+              </VoiceShoutProvider>
+            </AudioProvider>
+          </ThemeProvider>
+        </MotionProvider>
         <Analytics />
       </body>
     </html>

--- a/src/components/atoms/glitch-text/GlitchText.tsx
+++ b/src/components/atoms/glitch-text/GlitchText.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useReducedMotion } from 'framer-motion';
 import { useState, useRef } from 'react';
 import styles from './GlitchText.module.scss';
 
@@ -21,8 +22,10 @@ const SYMBOLS = '!@#$%^&*()_+-=[]{}|;:,.<>?';
 export default function GlitchText({ text, className = '', scrambleSpeed = 30 }: GlitchTextProps) {
   const [displayText, setDisplayText] = useState(text);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const reduceMotion = useReducedMotion();
 
   const scramble = () => {
+    if (reduceMotion) return;
     let iteration = 0;
     
     if (intervalRef.current) clearInterval(intervalRef.current);

--- a/src/components/atoms/motion-provider/MotionProvider.tsx
+++ b/src/components/atoms/motion-provider/MotionProvider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+
+/**
+ * App-wide framer-motion config: with `reducedMotion="user"` every motion
+ * component (page transitions, card pops, overlays, cursor pulses) respects
+ * the OS-level prefers-reduced-motion setting automatically.
+ */
+export default function MotionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/src/components/atoms/motion-provider/index.ts
+++ b/src/components/atoms/motion-provider/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MotionProvider";

--- a/src/components/atoms/text-scramble/TextScramble.tsx
+++ b/src/components/atoms/text-scramble/TextScramble.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useReducedMotion } from "framer-motion";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -21,8 +22,16 @@ export default function TextScramble({
   const [display, setDisplay] = useState(() => text.replace(/\S/g, CHARS[0]));
   const frameRef = useRef(0);
   const resolvedRef = useRef<boolean[]>([]);
+  const reduceMotion = useReducedMotion();
+
+  // Reduced motion: show the final text immediately, adjusting state during
+  // render (no scramble frames, no setState-in-effect).
+  if (reduceMotion && display !== text) {
+    setDisplay(text);
+  }
 
   useEffect(() => {
+    if (reduceMotion) return;
     resolvedRef.current = Array(text.length).fill(false);
     let iteration = 0;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -56,7 +65,7 @@ export default function TextScramble({
       clearTimeout(timeoutId);
       cancelAnimationFrame(frameRef.current);
     };
-  }, [text, delay]);
+  }, [text, delay, reduceMotion]);
 
   const T = Tag as React.ComponentType<{
     className?: string;

--- a/src/components/molecules/particle-logo/ParticleLogo.tsx
+++ b/src/components/molecules/particle-logo/ParticleLogo.tsx
@@ -3,6 +3,7 @@
 import { useTheme } from "@/context/ThemeContext";
 import { Html } from "@react-three/drei";
 import { Canvas, useFrame } from "@react-three/fiber";
+import { useReducedMotion } from "framer-motion";
 import Image from "next/image";
 import { useMemo, useRef, useState } from "react";
 import * as THREE from "three";
@@ -18,6 +19,7 @@ function getParticleCount(): number {
 
 function InteractiveParticles() {
   const { theme } = useTheme();
+  const reduceMotion = useReducedMotion();
 
   const particleCount = useMemo(() => getParticleCount(), []);
   const sphereRadius = 1.8;
@@ -70,6 +72,14 @@ function InteractiveParticles() {
     const targets = initialData.target;
     const vels = velocitiesRef.current;
     const time = clock.getElapsedTime();
+
+    // Reduced motion: particles rest in the sculpted logo shape — no
+    // breathing, no mouse repulsion, no drift.
+    if (reduceMotion) {
+      positions.set(targets);
+      geometryRef.current.attributes.position.needsUpdate = true;
+      return;
+    }
 
     for (let i = 0; i < particleCount; i++) {
       const ix = i * 3;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -374,3 +374,18 @@ button:not([data-no-stamp]),
     transform: translate(2px, -1px) rotate(0.1deg);
   }
 }
+
+/* ── Reduced motion ─────────────────────────────────────────────────────────
+   Collapse every decorative CSS animation and transition (ticker, glitch
+   slices, pulses, fades). JS-driven motion — framer, three.js, scramble —
+   is gated per component via useReducedMotion. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
Closes the last accessibility finding from the portfolio audit: JS-driven animations ignored the OS reduced-motion preference.

## Four layers

1. **Global CSS kill-switch** (globals.scss): under prefers-reduced-motion: reduce, every decorative CSS animation/transition collapses to 0.01ms — about ticker, glitch slices, live pulses, theme fades.
2. **MotionConfig reducedMotion="user"** at the app root (new MotionProvider atom): all framer-motion animations — page transitions, lab list pops, mobile overlay, cursor pulses — respect the OS setting with zero per-component code.
3. **TextScramble / GlitchText**: with reduced motion the final text renders immediately (no scramble frames); state adjusted during render, keeping the set-state-in-effect lint rule happy.
4. **ParticleLogo**: the home particles rest in the sculpted logo shape — no breathing, drift, or mouse repulsion. ThreeBackground, LogoMorph and BusinessCard3D already handled the preference.

Lint, build and 120 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)