### PR TITLE
fix: restore the mobile burger menu

### DIFF
--- a/src/components/templates/Layout/Layout.tsx
+++ b/src/components/templates/Layout/Layout.tsx
@@ -4,6 +4,7 @@ import Terminal from "@/components/organisms/Terminal";
 import { usePathname } from "next/navigation";
 import styles from "./layout.module.scss";
 import LeftColumn from "./LeftColumn";
+import MobileNav from "./MobileNav";
 import RightColumn from "./RightColumn";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -27,6 +28,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className={styles.container}>
       <Terminal />
+      <MobileNav />
       <LeftColumn />
       <main className={styles.main} data-fus-target="main">{children}</main>
       <RightColumn />

--- a/src/components/templates/Layout/MobileNav.tsx
+++ b/src/components/templates/Layout/MobileNav.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import Identity from "./Identity";
+import SiteNav from "./SiteNav";
+import SocialLinks from "./SocialLinks";
+import ThemeToggle from "./ThemeToggle";
+import styles from "./layout.module.scss";
+
+/**
+ * Mobile chrome: a carved burger that opens a full-screen overlay mirroring the
+ * desktop rails. It composes the exact same shared components (SiteNav,
+ * Identity, ThemeToggle, SocialLinks) — no duplicated markup, logic, or styles.
+ */
+export default function MobileNav() {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+  const [lastPathname, setLastPathname] = useState(pathname);
+
+  // Close the overlay on route change by adjusting state during render
+  // (React's recommended pattern) rather than a cascading setState-in-effect.
+  if (pathname !== lastPathname) {
+    setLastPathname(pathname);
+    setIsOpen(false);
+  }
+
+  const close = () => setIsOpen(false);
+
+  // Lock body scroll while the overlay is open
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`${styles.burger} ${isOpen ? styles.burgerOpen : ""}`}
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-label={isOpen ? "Close menu" : "Open menu"}
+        aria-expanded={isOpen}
+      >
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+
+      {isOpen && (
+        <div className={styles.overlay} role="dialog" aria-modal="true">
+          <div className={styles.overlayHead}>
+            <ThemeToggle />
+          </div>
+
+          <div className={styles.overlayCenter}>
+            <SiteNav onNavigate={close} showIndex={false} />
+          </div>
+
+          <div className={styles.overlayFoot}>
+            <Identity onCommand={close} />
+            <SocialLinks />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/templates/Layout/layout.module.scss
+++ b/src/components/templates/Layout/layout.module.scss
@@ -339,74 +339,131 @@
   }
 }
 
-// On mobile the same rails reflow into one compact fixed top bar — no separate
-// mobile chrome. The left rail becomes the bar shell (full width, glass, scribed
-// bottom edge); the right rail floats transparently on top of it, pinned right.
+// On mobile the desktop rails don't fit — they're hidden and replaced by the
+// carved burger + overlay (MobileNav), which reuses the same components.
 @include mobile {
   .leftColumn,
   .rightColumn {
-    top: 0;
-    bottom: auto;
-    width: auto;
-    height: var(--chrome-bar-height);
-    padding: 0 $spacing-md;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-
-    &.autoHide {
-      transform: none;
-
-      &:hover {
-        background: none;
-        backdrop-filter: none;
-      }
-    }
-  }
-
-  .leftColumn,
-  .leftColumn.autoHide {
-    left: 0;
-    right: 0;
-    background: rgba(var(--color-bg-rgb), 0.88);
-    backdrop-filter: blur($blur-md);
-    border: none;
-    border-bottom: $border-hairline solid var(--color-divider);
-  }
-
-  .leftColumn.autoHide:hover {
-    background: rgba(var(--color-bg-rgb), 0.88);
-    backdrop-filter: blur($blur-md);
-  }
-
-  .rightColumn,
-  .rightColumn.autoHide {
-    right: 0;
-    left: auto;
-    border: none;
-  }
-
-  .navbar {
-    flex-direction: row;
-  }
-
-  .siteNav {
-    flex-direction: row;
-    align-items: center;
-    gap: $spacing-md;
-    margin-top: 0;
-  }
-
-  // The compact strip only fits the nav and the theme pill: the divider,
-  // identity block, social handles and theme label live on the pages instead.
-  .divider,
-  .footer,
-  .socialLinks,
-  .themeLabel {
     display: none;
   }
+}
 
-  .main {
-    padding-top: var(--chrome-bar-height);
+// ── Mobile chrome — carved burger + mirror overlay (MobileNav) ───────────────
+// Desktop-only by default; shown under @include mobile. The overlay reuses the
+// shared rail components, so only the burger and overlay shell live here.
+
+.burger {
+  display: none; // shown on mobile only
+  position: fixed;
+  top: $spacing-md;
+  right: $spacing-md;
+  z-index: 200; // above the overlay so it stays tappable
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: $spacing-2xs;
+  width: $touch-target-min;
+  height: $touch-target-min;
+  padding: $spacing-xs;
+  background: rgba(var(--color-bg-rgb), 0.9);
+  border: $border-base solid var(--color-text);
+  border-radius: var(--route-card-radius, #{$radius-lg});
+  cursor: pointer;
+  // Match the carved wobble of the other chrome (rails/overlay); the Terminal
+  // stays glass so it deliberately keeps a crisp, un-inked edge.
+  filter: var(--ink-fine);
+
+  span {
+    display: block;
+    width: 18px; // burger glyph line — icon geometry, not layout
+    height: $border-base;
+    background-color: var(--color-text);
+    border-radius: $radius-full;
+    transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+      opacity 0.2s ease;
+    transform-origin: center;
   }
+
+  &.burgerOpen span:nth-child(1) {
+    transform: translateY(calc(#{$spacing-2xs} + #{$border-base})) rotate(45deg);
+  }
+  &.burgerOpen span:nth-child(2) {
+    opacity: 0;
+  }
+  &.burgerOpen span:nth-child(3) {
+    transform: translateY(calc(-1 * (#{$spacing-2xs} + #{$border-base}))) rotate(-45deg);
+  }
+
+  @include mobile {
+    display: flex;
+  }
+}
+
+// Full-screen menu: large centered navigation, action controls in the corners.
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 150;
+  display: flex;
+  flex-direction: column;
+  background: rgba(var(--color-bg-rgb), 0.92);
+  backdrop-filter: blur($blur-md);
+  -webkit-backdrop-filter: blur($blur-md);
+  overflow-y: auto;
+  filter: var(--ink-fine);
+  padding: $spacing-md $spacing-xl $spacing-2xl;
+  animation: overlayFade 0.25s ease;
+}
+
+@keyframes overlayFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+// Top-left action — theme toggle, on the same row as the burger (top-right)
+.overlayHead {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: $touch-target-min;
+  // leave room so it never collides with the fixed burger on the right
+  padding-right: calc(#{$touch-target-min} + #{$spacing-sm});
+  flex-shrink: 0;
+}
+
+// Centered, oversized navigation
+.overlayCenter {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .siteNav {
+    align-items: center;
+    gap: $spacing-xl;
+  }
+
+  .navLink {
+    font-size: clamp(#{$font-size-2xl}, 12vw, #{$font-size-4xl});
+    letter-spacing: $letter-spacing-tighter;
+    opacity: 0.45;
+    line-height: 1.05;
+  }
+
+  .navLinkActive {
+    opacity: 1;
+  }
+}
+
+// Bottom row — identity (left) and socials (right, vertical), same level
+.overlayFoot {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: $spacing-lg;
+  flex-shrink: 0;
 }

--- a/src/styles/adaptive.scss
+++ b/src/styles/adaptive.scss
@@ -38,7 +38,6 @@
   --chrome-rail-width: 328px; // desktop side-rail width
   --chrome-rail-pad-x: 40px; // desktop side-rail horizontal padding
   --chrome-rail-peek: 32px; // visible sliver of an auto-hidden rail (hover target)
-  --chrome-bar-height: 56px; // mobile top bar the rails reflow into
 
   // ── Cards ────────────────────────────────────────────────────────────────────
   --route-card-shadow: var(--depth-sm);


### PR DESCRIPTION
## Why

The unified top-bar chrome from #13 turned out unusable on mobile: the inline nav strip was too cramped to operate. User feedback: the burger menu must come back.

## What

- Restore MobileNav (carved burger + fullscreen overlay) from the pre-#13 tree. It composes the same shared components (SiteNav, Identity, ThemeToggle, SocialLinks), so no duplicated markup or logic returns.
- layout.module.scss: replace the mobile rail-reflow block with the previous display: none for the rails under the mobile breakpoint, and bring back the burger/overlay styles.
- Drop the now-unused --chrome-bar-height token from adaptive.scss.

The token sweep from #13 is untouched.

## Verified

- Lint clean, 120/120 tests, production build passes.
- Post-hydration screenshots: 375x812 shows the burger top-right and no rails; 1440x900 /lab unchanged with auto-hidden rails.

Generated with [Claude Code](https://claude.com/claude-code)