### PR TITLE
fix: force text presentation on emoji-capable glyphs

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -6,7 +6,7 @@
 
 ---
 
-## 🌐 Sito (`/`, `/lab`, e tutte le pagine pubbliche)
+## Sito (`/`, `/lab`, e tutte le pagine pubbliche)
 
 ### Navigazione
 
@@ -56,7 +56,7 @@ lab  ·  search  ·  guide  ·  theme  ·  whoami  ·  help
 
 ---
 
-## 🔒 Admin Terminal (`/admin`)
+## Admin Terminal (`/admin`)
 
 Accessibile solo dopo login. Stesso shortcut `Cmd+K`.
 
@@ -93,7 +93,7 @@ list  ·  add  ·  status  ·  theme  ·  logout  ·  site
 
 ---
 
-## 🔗 Deep Links
+## Deep Links
 
 You can share a direct link to any terminal command using the `?cmd=` URL parameter.
 When someone opens the link, the terminal auto-opens and executes the command.
@@ -122,7 +122,7 @@ Click it to copy the deep link for that command to your clipboard.
 
 ---
 
-## ⌨️ Scorciatoie globali
+## Scorciatoie globali
 
 | Tasto | Azione |
 |---|---|
@@ -137,7 +137,7 @@ Click it to copy the deep link for that command to your clipboard.
 
 ---
 
-## 🤖 Autocomplete
+## Autocomplete
 
 Il terminale carica automaticamente i dati dal DB per suggerire:
 
@@ -153,7 +153,7 @@ Il terminale carica automaticamente i dati dal DB per suggerire:
 
 ---
 
-## 🐍 Snake — ASCII Game
+## Snake — ASCII Game
 
 Digita `snake` (o `play`) nel terminale per avviare il gioco.
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -151,7 +151,7 @@ export default function AboutPage() {
             rel="noreferrer"
             className={styles.contactLink}
           >
-            LinkedIn ↗
+            LinkedIn {"↗︎"}
           </a>
           <a
             href="https://github.com/IvanDF"
@@ -159,10 +159,10 @@ export default function AboutPage() {
             rel="noreferrer"
             className={styles.contactLink}
           >
-            GitHub ↗
+            GitHub {"↗︎"}
           </a>
           <Link href="/lab" className={styles.contactLink}>
-            Work ↗
+            Work {"↗︎"}
           </Link>
         </div>
       </section>

--- a/src/app/lab/page.tsx
+++ b/src/app/lab/page.tsx
@@ -113,7 +113,9 @@ export default function Lab() {
               <div className={styles.rowMeta}>
                 <span className={styles.rowCategory}>{project.category}</span>
                 <span className={styles.rowYear}>{project.year}</span>
-                {project.status === "live" && <span className={styles.rowArrow}>↗</span>}
+                {/* ︎ forces text presentation: without it iOS falls back
+                    to Apple Color Emoji when the webfont lacks the glyph */}
+                {project.status === "live" && <span className={styles.rowArrow}>{"↗︎"}</span>}
               </div>
             </button>
           ))}

--- a/src/app/time-machine/page.tsx
+++ b/src/app/time-machine/page.tsx
@@ -102,7 +102,7 @@ export default function TimeMachinePage() {
               rel="noopener noreferrer"
               className={styles.tvOpenLink}
             >
-              ↗ open in new tab
+              {"↗︎"} open in new tab
             </a>
           </div>
         )}

--- a/src/components/organisms/Terminal/SnakeGame.tsx
+++ b/src/components/organisms/Terminal/SnakeGame.tsx
@@ -113,9 +113,10 @@ export default function SnakeGame({ onExit }: SnakeGameProps) {
           <button className={styles.dpadBtn} onClick={() => queueDir(UP_DIR)}>▲</button>
         </div>
         <div className={styles.dpadRow}>
-          <button className={styles.dpadBtn} onClick={() => queueDir(LEFT_DIR)}>◀</button>
+          {/* ︎ keeps these as text glyphs — iOS otherwise swaps ◀ ▶ for emoji */}
+          <button className={styles.dpadBtn} onClick={() => queueDir(LEFT_DIR)}>{"◀︎"}</button>
           <button className={styles.dpadBtn} onClick={() => queueDir(DOWN_DIR)}>▼</button>
-          <button className={styles.dpadBtn} onClick={() => queueDir(RIGHT_DIR)}>▶</button>
+          <button className={styles.dpadBtn} onClick={() => queueDir(RIGHT_DIR)}>{"▶︎"}</button>
         </div>
       </div>
     </div>

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -141,6 +141,10 @@ body {
   background-color: var(--color-bg);
   color: var(--color-text);
   overflow: hidden;
+  // Emoji-capable glyphs (arrows, play triangles) must render as text, never
+  // as color emoji — iOS falls back to Apple Color Emoji when the webfont
+  // lacks a glyph. Belt and braces with the U+FE0E selectors in the markup.
+  font-variant-emoji: text;
 
   @media (prefers-reduced-motion: no-preference) {
     transition:


### PR DESCRIPTION
## Why

On iPhone the project list on /lab (and the Snake d-pad) showed color emoji: the webfonts lack U+2197 (arrow) and U+25B6/U+25C0 (triangles), so iOS falls back to Apple Color Emoji. The emoji glyphs are taller than the line box, so they also looked clipped at the top of the row boxes. On desktop they render as plain text, which is why it never showed in screenshots.

## What

- Append U+FE0E (text variation selector) to every emoji-capable glyph: the /lab row arrow, the three about-page contact links, the time-machine open link, and the Snake d-pad left/right triangles.
- Set font-variant-emoji: text on html/body as a global second guard (Safari 17.4+, Chrome 131+).
- Strip decorative emoji from docs/COMMANDS.md headings for coherence with the zero-emoji rule.

## Verified

- Lint clean, 120/120 tests, production build passes.

Generated with [Claude Code](https://claude.com/claude-code)