### PR TITLE
Blob cursor with wave morph + hover performance fixes

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: verify
+description: Build, run, and drive idf-hub to verify changes at the browser surface.
+---
+
+# Verifying idf-hub changes
+
+Host has no node: everything JS runs inside the `node-tool` toolbox container.
+
+```bash
+toolbox run -c node-tool sh -c 'npm run dev'          # dev server on :3000 (background)
+toolbox run -c node-tool sh -c 'npm run build'        # production build
+toolbox run -c node-tool sh -c 'npm test'             # jest (CI territory, not verification)
+```
+
+## Driving the UI
+
+Playwright chromium-headless-shell is installed at `~/.cache/ms-playwright`
+(runtime libs already dnf-installed in the toolbox). Set up a scratch dir with
+`npm install playwright-core`, then drive `http://localhost:3000` with
+`chromium.launch()` from a node script run inside the toolbox.
+
+Gotchas:
+- An "Immersive Audio" modal covers every page on first visit and blocks all
+  hover/pointer checks. Dismiss it first: click `[class*="declineBtn"]`
+  (getByRole with the button name did not match it).
+- The custom cursor only mounts when `(hover: none) and (pointer: coarse)` is
+  false; playwright's default blink settings already report a fine pointer.
+- Cursor elements: `[class*="cursorDot"]`, `[class*="cursorBlob"]` (inner
+  `[class*="blobShape"]` runs the wave morph). They sit at -100,-100 until the
+  first mousemove.
+- Global magnetism writes inline `translate` on hovered links/buttons; it is
+  size-gated (skips elements larger than 320x120), so project rows on /lab must
+  NOT get an inline translate while filter buttons must.
+- `el.style.translate` normalizes `"0px 0px"` to `"0px"` — compare accordingly.

--- a/src/app/lab/page.module.scss
+++ b/src/app/lab/page.module.scss
@@ -144,16 +144,21 @@
   cursor: pointer;
   transition:
     background 0.12s ease,
-    padding 0.12s ease,
     border-color 0.12s ease;
   width: 100%;
   box-sizing: border-box;
 
+  // The hover indent moves via `translate` on the children instead of
+  // animating padding: padding retriggers layout of the whole list every
+  // frame, and the ink-filtered ancestor re-filters on top of that.
   &:hover {
     background: var(--color-text);
-    padding-left: $spacing-md;
-    padding-right: $spacing-md;
     border-color: var(--color-text);
+
+    .rowNum,
+    .rowMain { translate: ($spacing-md - $spacing-xs) 0; }
+
+    .rowMeta { translate: (-($spacing-md - $spacing-xs)) 0; }
 
     .rowNum,
     .rowTitle,
@@ -176,11 +181,6 @@
     grid-template-columns: $spacing-xl 1fr auto;
     gap: $spacing-sm;
     padding: $spacing-md $spacing-2xs;
-
-    &:hover {
-      padding-left: $spacing-sm;
-      padding-right: $spacing-sm;
-    }
   }
 }
 
@@ -193,7 +193,7 @@
   flex-shrink: 0;
   align-self: start;
   padding-top: $spacing-2xs;
-  transition: color 0.15s ease;
+  transition: color 0.15s ease, translate 0.12s ease;
 }
 
 .rowMain {
@@ -201,6 +201,7 @@
   flex-direction: column;
   gap: $spacing-2xs;
   min-width: 0;
+  transition: translate 0.12s ease;
 }
 
 .rowTitle {
@@ -239,6 +240,7 @@
   align-items: center;
   gap: $spacing-sm;
   flex-shrink: 0;
+  transition: translate 0.12s ease;
 }
 
 .rowCategory {

--- a/src/components/atoms/custom-cursor/CustomCursor.module.scss
+++ b/src/components/atoms/custom-cursor/CustomCursor.module.scss
@@ -13,16 +13,63 @@
   mix-blend-mode: difference;
 }
 
-.cursorRing {
+.cursorBlob {
   position: fixed;
   top: 0;
   left: 0;
   width: $size-cursor-ring;
   height: $size-cursor-ring;
-  border: $border-hairline solid #fff;
-  border-radius: 50%;
   pointer-events: none;
   z-index: 1000000;
+}
+
+// The wave morph lives on an inner element: Framer Motion owns the outer
+// transform, so rotation/border-radius keyframes here never conflict with it.
+.blobShape {
+  width: 100%;
+  height: 100%;
+  border: $border-hairline solid #fff;
+  background-color: rgb(255 255 255 / 8%);
   mix-blend-mode: difference;
-  background-color: transparent;
+  border-radius: 58% 42% 55% 45% / 50% 58% 42% 55%;
+  animation: blob-wave 9s linear infinite;
+
+  .cursorBlob[data-hovering="true"] & {
+    border-width: 2px;
+    background-color: rgb(255 255 255 / 14%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    border-radius: 50%;
+  }
+}
+
+// Asymmetric radii + slow rotation read as a liquid wave; the loop endpoints
+// match so the cycle never pops.
+@keyframes blob-wave {
+  0% {
+    border-radius: 58% 42% 55% 45% / 50% 58% 42% 55%;
+    transform: rotate(0deg);
+  }
+
+  25% {
+    border-radius: 45% 55% 42% 58% / 58% 45% 55% 42%;
+    transform: rotate(90deg);
+  }
+
+  50% {
+    border-radius: 55% 45% 58% 42% / 42% 55% 45% 58%;
+    transform: rotate(180deg);
+  }
+
+  75% {
+    border-radius: 42% 58% 45% 55% / 55% 42% 58% 45%;
+    transform: rotate(270deg);
+  }
+
+  100% {
+    border-radius: 58% 42% 55% 45% / 50% 58% 42% 55%;
+    transform: rotate(360deg);
+  }
 }

--- a/src/components/atoms/custom-cursor/CustomCursor.tsx
+++ b/src/components/atoms/custom-cursor/CustomCursor.tsx
@@ -5,6 +5,18 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import styles from "./CustomCursor.module.scss";
 
+// Magnetism only reads as "magnetic" on compact controls; on large surfaces
+// (e.g. full-width list rows) it just drags the whole block around and forces
+// the ink filter to re-run over the page every frame.
+const MAX_MAGNET_WIDTH = 320;
+const MAX_MAGNET_HEIGHT = 120;
+
+type MagnetEntry = {
+  el: HTMLElement;
+  rect: DOMRect;
+  eligible: boolean;
+};
+
 /**
  * CustomCursor Component
  *
@@ -14,7 +26,7 @@ import styles from "./CustomCursor.module.scss";
  * lives in the CSS module to keep the visual system consistent.
  * Features:
  * - Central dot that follows mouse instantly
- * - Outer ring with spring physics (magnetic feel)
+ * - Outer blob with tight spring physics and a continuous wave morph
  * - Hover state (scales up)
  * - Click state (pulses)
  * - Disappears on touch devices
@@ -30,11 +42,13 @@ export default function CustomCursor() {
   const mouseX = useMotionValue(-100);
   const mouseY = useMotionValue(-100);
 
-  // Spring physics for the outer ring (delayed follow)
-  const springConfig = { damping: 25, stiffness: 300 };
-  const ringX = useSpring(mouseX, springConfig);
-  const ringY = useSpring(mouseY, springConfig);
-  const activeMagnetElRef = useRef<HTMLElement | null>(null);
+  // Spring physics for the blob: stiff enough to stay glued to the dot
+  // (a soft spring here reads as page lag), soft enough to keep a hint
+  // of organic overshoot.
+  const springConfig = { damping: 32, stiffness: 750, mass: 0.8 };
+  const blobX = useSpring(mouseX, springConfig);
+  const blobY = useSpring(mouseY, springConfig);
+  const activeMagnetRef = useRef<MagnetEntry | null>(null);
 
   useEffect(() => {
     // Only enable on desktop devices
@@ -46,18 +60,15 @@ export default function CustomCursor() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsVisible(true);
 
-    let lastMoveCalled = 0;
-    const THROTTLE_MS = 1000 / 60; // 60fps cap
-
-    const moveCursor = (e: MouseEvent) => {
-      mouseX.set(e.clientX);
-      mouseY.set(e.clientY);
+    const resetMagnetElement = (entry: MagnetEntry | null) => {
+      if (!entry?.eligible) return;
+      entry.el.style.setProperty("translate", "0px 0px");
+      entry.el.style.removeProperty("will-change");
     };
 
-    const resetMagnetElement = (element: HTMLElement | null) => {
-      if (!element) return;
-      element.style.setProperty("translate", "0px 0px");
-      element.style.removeProperty("will-change");
+    const clearMagnetism = () => {
+      resetMagnetElement(activeMagnetRef.current);
+      activeMagnetRef.current = null;
     };
 
     const applyGlobalMagnetism = (e: MouseEvent) => {
@@ -68,23 +79,31 @@ export default function CustomCursor() {
 
       // Keep local Magnetic components in control.
       if (!candidate || candidate.closest("[data-local-magnetic='true']")) {
-        if (activeMagnetElRef.current) {
-          resetMagnetElement(activeMagnetElRef.current);
-          activeMagnetElRef.current = null;
-        }
+        clearMagnetism();
         return;
       }
 
-      if (
-        activeMagnetElRef.current &&
-        activeMagnetElRef.current !== candidate
-      ) {
-        resetMagnetElement(activeMagnetElRef.current);
+      let entry = activeMagnetRef.current;
+      if (!entry || entry.el !== candidate) {
+        resetMagnetElement(entry);
+        // Measure once per candidate instead of every mousemove: reading the
+        // rect after writing `translate` forces a synchronous layout per frame.
+        const rect = candidate.getBoundingClientRect();
+        entry = {
+          el: candidate,
+          rect,
+          eligible:
+            rect.width <= MAX_MAGNET_WIDTH && rect.height <= MAX_MAGNET_HEIGHT,
+        };
+        activeMagnetRef.current = entry;
+        if (entry.eligible) {
+          candidate.style.setProperty("will-change", "translate");
+        }
       }
 
-      activeMagnetElRef.current = candidate;
+      if (!entry.eligible) return;
 
-      const rect = candidate.getBoundingClientRect();
+      const { rect } = entry;
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
       const normalizedX = (e.clientX - centerX) / Math.max(rect.width, 1);
@@ -93,27 +112,18 @@ export default function CustomCursor() {
       const offsetX = Math.max(-1, Math.min(1, normalizedX)) * maxOffset;
       const offsetY = Math.max(-1, Math.min(1, normalizedY)) * maxOffset;
 
-      candidate.style.setProperty("will-change", "translate");
-      candidate.style.setProperty(
+      entry.el.style.setProperty(
         "translate",
         `${offsetX.toFixed(2)}px ${offsetY.toFixed(2)}px`,
       );
     };
 
-    // Single throttled handler combining position update + magnetism (avoids two separate listeners)
+    // Unthrottled: motion values already coalesce to one render per frame,
+    // and capping at 60fps made the dot stutter on high-refresh displays.
     const handleMouseMove = (e: MouseEvent) => {
-      const now = performance.now();
-      if (now - lastMoveCalled < THROTTLE_MS) return;
-      lastMoveCalled = now;
-      moveCursor(e);
+      mouseX.set(e.clientX);
+      mouseY.set(e.clientY);
       applyGlobalMagnetism(e);
-    };
-
-    const clearMagnetism = () => {
-      if (activeMagnetElRef.current) {
-        resetMagnetElement(activeMagnetElRef.current);
-        activeMagnetElRef.current = null;
-      }
     };
 
     const handleMouseDown = () => setIsClicking(true);
@@ -147,6 +157,11 @@ export default function CustomCursor() {
     window.addEventListener("mouseover", handleMouseOver);
     window.addEventListener("mouseleave", clearMagnetism);
     window.addEventListener("blur", clearMagnetism);
+    // Cached rects go stale when the page scrolls under the pointer.
+    window.addEventListener("scroll", clearMagnetism, {
+      passive: true,
+      capture: true,
+    });
 
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
@@ -155,6 +170,7 @@ export default function CustomCursor() {
       window.removeEventListener("mouseover", handleMouseOver);
       window.removeEventListener("mouseleave", clearMagnetism);
       window.removeEventListener("blur", clearMagnetism);
+      window.removeEventListener("scroll", clearMagnetism, { capture: true });
       clearMagnetism();
     };
   }, [mouseX, mouseY]);
@@ -180,20 +196,24 @@ export default function CustomCursor() {
         transition={{ duration: 0.1 }}
       />
 
-      {/* Outer Ring (Spring Follow) */}
+      {/* Outer Blob (Spring Follow + Wave Morph) */}
+      {/* Framer owns the outer transform (position/scale); the inner shape
+          runs the CSS wave morph so the two never fight over `transform`. */}
       <motion.div
-        className={styles.cursorRing}
-        style={{ translateX: ringX, translateY: ringY, x: "-50%", y: "-50%" }}
+        className={styles.cursorBlob}
+        data-hovering={isHovering}
+        style={{ translateX: blobX, translateY: blobY, x: "-50%", y: "-50%" }}
         animate={{
           scale: isClicking ? 0.8 : isHovering ? 1.5 : 1, // Expand on hover
           opacity: isHovering ? 0.8 : 0.4,
-          borderWidth: isHovering ? "2px" : "1px",
         }}
         transition={{
           scale: { duration: 0.2 },
           opacity: { duration: 0.2 },
         }}
-      />
+      >
+        <div className={styles.blobShape} />
+      </motion.div>
     </>
   );
 }


### PR DESCRIPTION
## What

**Cursor:** the outer ring is now a blob. It follows on a much stiffer spring (damping 32, stiffness 750) so it stays glued to the dot instead of trailing behind it - the soft trail was reading as page lag. An inner element cycles through asymmetric border-radius keyframes with a slow rotation for a continuous liquid-wave morph (Framer keeps ownership of the outer transform, so the two never fight). Respects prefers-reduced-motion.

**Performance:**
- Removed the 60fps mousemove throttle: motion values already coalesce to one render per frame, and the cap made the dot stutter on high-refresh displays.
- Global magnetism now measures the target rect once per candidate (invalidated on scroll) instead of calling getBoundingClientRect on every mousemove after writing translate - that was a forced synchronous layout per frame.
- Magnetism is size-gated (320x120 max): full-width /lab project rows were being dragged around by it, forcing the ink SVG filter to re-run over the whole page on every mouse move.
- The /lab row hover indent moved from animated padding (relayout of the entire list per frame, under the ink filter) to translate on the row children. Same visual, compositor-friendly.

Also adds a project verify skill (.claude/skills/verify) with the toolbox build/run/drive recipe.

## Verification

Drove /lab and the homepage with headless Chromium against the dev server:
- blob morph animating (computed border-radius changes over time), ring gone
- after a fast 700px mouse jump the blob closes the gap in under 100ms
- hovered project row: inverted background, children translated +8/-8px, no inline translate or will-change on the row (magnetism correctly skipped)
- hovered filter button: magnetism applies (inline translate + will-change), resets on mouse-off and on scroll
- rapid sweep across all rows leaves no stale translated elements
- 120/120 jest tests, eslint and production build clean

Generated with [Claude Code](https://claude.com/claude-code)
