### PR TITLE
Fix blob cursor visibility on light theme, stronger morph

### DIFF
--- a/src/components/atoms/custom-cursor/CustomCursor.module.scss
+++ b/src/components/atoms/custom-cursor/CustomCursor.module.scss
@@ -21,23 +21,22 @@
   height: $size-cursor-ring;
   pointer-events: none;
   z-index: 1000000;
+  // The blend must sit on this outer element: its transform/opacity isolate
+  // any child's blend into an empty group, so `difference` on the inner
+  // shape silently no-ops and the blob vanishes on the light theme.
+  mix-blend-mode: difference;
 }
 
 // The wave morph lives on an inner element: Framer Motion owns the outer
 // transform, so rotation/border-radius keyframes here never conflict with it.
+// Solid silk fill blended as difference by the parent: the blob reads as a
+// negative of whatever it covers, same as the dot, on both themes.
 .blobShape {
   width: 100%;
   height: 100%;
-  border: $border-hairline solid #fff;
-  background-color: rgb(255 255 255 / 8%);
-  mix-blend-mode: difference;
-  border-radius: 58% 42% 55% 45% / 50% 58% 42% 55%;
-  animation: blob-wave 9s linear infinite;
-
-  .cursorBlob[data-hovering="true"] & {
-    border-width: 2px;
-    background-color: rgb(255 255 255 / 14%);
-  }
+  background-color: $color-silk-light;
+  border-radius: 63% 37% 52% 48% / 45% 62% 38% 55%;
+  animation: blob-wave 6s linear infinite;
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;
@@ -45,31 +44,32 @@
   }
 }
 
-// Asymmetric radii + slow rotation read as a liquid wave; the loop endpoints
-// match so the cycle never pops.
+// Asymmetric radii + continuous rotation read as a liquid wave; the rotation
+// stays linear (angle proportional to progress) and the loop endpoints match
+// so the cycle never pops.
 @keyframes blob-wave {
   0% {
-    border-radius: 58% 42% 55% 45% / 50% 58% 42% 55%;
+    border-radius: 63% 37% 52% 48% / 45% 62% 38% 55%;
     transform: rotate(0deg);
   }
 
-  25% {
-    border-radius: 45% 55% 42% 58% / 58% 45% 55% 42%;
-    transform: rotate(90deg);
+  20% {
+    border-radius: 40% 60% 65% 35% / 58% 42% 60% 40%;
+    transform: rotate(72deg);
   }
 
-  50% {
-    border-radius: 55% 45% 58% 42% / 42% 55% 45% 58%;
-    transform: rotate(180deg);
+  45% {
+    border-radius: 55% 45% 38% 62% / 64% 36% 48% 52%;
+    transform: rotate(162deg);
   }
 
-  75% {
-    border-radius: 42% 58% 45% 55% / 55% 42% 58% 45%;
-    transform: rotate(270deg);
+  70% {
+    border-radius: 36% 64% 58% 42% / 40% 58% 35% 65%;
+    transform: rotate(252deg);
   }
 
   100% {
-    border-radius: 58% 42% 55% 45% / 50% 58% 42% 55%;
+    border-radius: 63% 37% 52% 48% / 45% 62% 38% 55%;
     transform: rotate(360deg);
   }
 }

--- a/src/components/atoms/custom-cursor/CustomCursor.tsx
+++ b/src/components/atoms/custom-cursor/CustomCursor.tsx
@@ -201,11 +201,12 @@ export default function CustomCursor() {
           runs the CSS wave morph so the two never fight over `transform`. */}
       <motion.div
         className={styles.cursorBlob}
-        data-hovering={isHovering}
         style={{ translateX: blobX, translateY: blobY, x: "-50%", y: "-50%" }}
         animate={{
           scale: isClicking ? 0.8 : isHovering ? 1.5 : 1, // Expand on hover
-          opacity: isHovering ? 0.8 : 0.4,
+          // Solid difference fill needs high opacity to read as a negative;
+          // dropping it much lower fades the inversion into grey.
+          opacity: isHovering ? 1 : 0.85,
         }}
         transition={{
           scale: { duration: 0.2 },


### PR DESCRIPTION
## What

Follow-up to #16 after design review: on the light theme the blob rendered as a raw near-white fill and was effectively invisible.

- **Root cause:** `mix-blend-mode: difference` sat on the inner morph shape, but its parent (transformed and faded by Framer Motion) isolates the child's blend into an empty group, so the blend silently no-opped. The blend now lives on the outer element, where it composites against the page exactly like the dot.
- **Design system:** the hardcoded `#fff` is gone; the blob uses `$color-silk-light` like the dot.
- **True negative:** the fill is now solid, so the blob inverts whatever it covers on both themes (dark blob on light theme, light blob on dark, re-inverts over hovered rows).
- **More blob:** wider border-radius range (36-65%) and a faster 6s cycle for a more irregular, livelier wave morph.

## Verification

Drove /lab with headless Chromium on both themes (dismissing the audio prompt, toggling with the `d` shortcut):

- light theme: dark irregular blob, clearly visible over background and text, dot re-inverted inside
- dark theme: light blob over background; over a hovered (inverted) row it flips dark again - negative in every combination
- computed style confirms the silk token fill and the 6s morph animation running
- 120/120 jest tests, eslint and production build clean

Generated with [Claude Code](https://claude.com/claude-code)
