### PR TITLE
Design-system coverage: time machine, terminal chips, snake, envelope gaps

### DIFF
--- a/src/app/lab/page.module.scss
+++ b/src/app/lab/page.module.scss
@@ -151,14 +151,51 @@
   // The hover indent moves via `translate` on the children instead of
   // animating padding: padding retriggers layout of the whole list every
   // frame, and the ink-filtered ancestor re-filters on top of that.
+  // On fine-pointer devices the color inversion comes from the cursor blob
+  // enveloping the row (difference blend), so hover only adds motion there.
   &:hover {
-    background: var(--color-text);
-    border-color: var(--color-text);
-
     .rowNum,
     .rowMain { translate: ($spacing-md - $spacing-xs) 0; }
 
     .rowMeta { translate: (-($spacing-md - $spacing-xs)) 0; }
+
+    .rowNum,
+    .rowTitle,
+    .rowDesc,
+    .rowCategory,
+    .rowYear,
+    .rowArrow {
+      opacity: 1;
+    }
+
+    .rowDesc { opacity: 0.65; }
+
+    .rowArrow {
+      transform: translate(3px, -3px);
+    }
+  }
+
+  // CSS inversion fallback where there is no blob cursor: touch tap
+  // highlight and keyboard focus.
+  @media (hover: none), (pointer: coarse) {
+    &:hover {
+      background: var(--color-text);
+      border-color: var(--color-text);
+
+      .rowNum,
+      .rowTitle,
+      .rowDesc,
+      .rowCategory,
+      .rowYear,
+      .rowArrow {
+        color: var(--color-bg);
+      }
+    }
+  }
+
+  &:focus-visible {
+    background: var(--color-text);
+    border-color: var(--color-text);
 
     .rowNum,
     .rowTitle,
@@ -171,10 +208,6 @@
     }
 
     .rowDesc { opacity: 0.65; }
-
-    .rowArrow {
-      transform: translate(3px, -3px);
-    }
   }
 
   @include mobile {

--- a/src/app/time-machine/TimeMachine.module.scss
+++ b/src/app/time-machine/TimeMachine.module.scss
@@ -81,16 +81,18 @@
     height: 100%;
   }
 
+  // Chromatic aberration built from the palette: secondary (lario) on one
+  // side, accent (volta) on the other, instead of raw cyan/magenta.
   &::before {
     left: 2px;
-    text-shadow: -1px 0 #00ffff; /* intentional: glitch chromatic aberration */
+    text-shadow: -1px 0 $color-secondary-dark;
     clip: rect(44px, 450px, 56px, 0);
     animation: glitch-anim 5s infinite linear alternate-reverse;
   }
 
   &::after {
     left: -2px;
-    text-shadow: -1px 0 #ff00ff; /* intentional: glitch chromatic aberration */
+    text-shadow: -1px 0 $color-accent-dark;
     clip: rect(44px, 450px, 56px, 0);
     animation: glitch-anim2 5s infinite linear alternate-reverse;
   }
@@ -106,6 +108,8 @@
   animation: float 6s ease-in-out infinite;
 }
 
+// Fixed-dark scene: colors come from the dark-theme side of the palette
+// (secondary = lario, accent = volta) instead of raw hexes or the light set.
 .hologramRing {
   position: absolute;
   top: 50%;
@@ -113,24 +117,24 @@
   transform: translate(-50%, -50%);
   width: 120%;
   height: 120%;
-  border: $border-hairline solid color.adjust($color-lario-light, $alpha: -0.7);
-  border-radius: $radius-lg;
-  background: radial-gradient(circle, color.adjust($color-lario-light, $alpha: -0.95) 0%, transparent 70%);
+  border: $border-hairline solid color.adjust($color-secondary-dark, $alpha: -0.7);
+  border-radius: var(--route-card-radius, #{$radius-lg});
+  background: radial-gradient(circle, color.adjust($color-secondary-dark, $alpha: -0.95) 0%, transparent 70%);
 
-  box-shadow: 0 0 50px color.adjust($color-lario-light, $alpha: -0.9);
+  box-shadow: 0 0 50px color.adjust($color-secondary-dark, $alpha: -0.9);
 }
 
 .artifactCard {
   position: relative;
   background: color.adjust($color-silk-dark, $alpha: -0.2);
-  border: $border-hairline solid color.adjust($color-lario-light, $alpha: -0.5);
+  border: $border-hairline solid color.adjust($color-secondary-dark, $alpha: -0.5);
   backdrop-filter: blur($blur-md);
   padding: $spacing-xl;
-  border-radius: $radius-sm;
-  box-shadow: 
-    0 0 20px color.adjust($color-lario-light, $alpha: -0.9),
-    inset 0 0 20px color.adjust($color-lario-light, $alpha: -0.95);
-  
+  border-radius: var(--route-card-radius, #{$radius-lg});
+  box-shadow:
+    0 0 20px color.adjust($color-secondary-dark, $alpha: -0.9),
+    inset 0 0 20px color.adjust($color-secondary-dark, $alpha: -0.95);
+
   &::before {
     content: '';
     position: absolute;
@@ -138,9 +142,9 @@
     left: -$border-hairline;
     right: -$border-hairline;
     bottom: -$border-hairline;
-    background: linear-gradient(45deg, color.adjust($color-lario-light, $alpha: -0.5), transparent, color.adjust($color-volta-light, $alpha: -0.5));
+    background: linear-gradient(45deg, color.adjust($color-secondary-dark, $alpha: -0.5), transparent, color.adjust($color-accent-dark, $alpha: -0.5));
     z-index: -1;
-    border-radius: $radius-sm;
+    border-radius: var(--route-card-radius, #{$radius-lg});
     opacity: 0.5;
   }
 }
@@ -151,21 +155,21 @@
   gap: $spacing-sm;
   margin-bottom: $spacing-lg;
   padding-bottom: $spacing-md;
-  border-bottom: $border-hairline solid color.adjust($color-white, $alpha: -0.9);
+  border-bottom: $border-hairline solid color.adjust($color-silk-light, $alpha: -0.9);
 }
 
 .icon {
-  color: $color-lario-dark;
+  color: $color-secondary-dark;
 }
 
 .idBadge {
   font-size: $font-size-sm;
-  color: $color-lario-dark;
+  color: $color-secondary-dark;
   letter-spacing: $letter-spacing-lg;
-  background: color.adjust($color-lario-light, $alpha: -0.9);
+  background: color.adjust($color-secondary-dark, $alpha: -0.9);
   padding: $spacing-xs $spacing-sm;
-  border-radius: $radius-sm;
-  border: $border-hairline solid color.adjust($color-lario-light, $alpha: -0.8);
+  border-radius: var(--route-filter-radius, #{$radius-md});
+  border: $border-hairline solid color.adjust($color-secondary-dark, $alpha: -0.8);
 }
 
 .artifactTitle {
@@ -174,7 +178,7 @@
   color: $color-silk-light;
   margin-bottom: $spacing-sm;
   letter-spacing: $letter-spacing-tighter;
-  text-shadow: 0 0 10px color.adjust($color-white, $alpha: -0.7);
+  text-shadow: 0 0 10px color.adjust($color-silk-light, $alpha: -0.7);
 }
 
 .artifactMeta {
@@ -196,7 +200,7 @@
   line-height: 1.6;
   margin-bottom: $spacing-xl;
   font-size: $font-size-md;
-  border-left: $border-base solid $color-lario-light;
+  border-left: $border-base solid $color-secondary-dark;
   padding-left: $spacing-md;
 }
 
@@ -205,27 +209,31 @@
   gap: $spacing-md;
 }
 
+// Mirrors the site primary CTA on the dark side of the palette:
+// accent background, bg-colored text, squircle radius.
 .primaryAction {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: $spacing-sm;
-  background: $color-lario-light;
-  color: $color-silk-light;
+  background: $color-accent-dark;
+  color: $color-silk-dark;
   padding: $spacing-sm $spacing-lg;
   text-decoration: none;
   font-weight: 600;
-  border: $border-hairline solid $color-lario-light;
-  border-radius: $radius-md;
+  border: $border-hairline solid $color-accent-dark;
+  border-radius: var(--route-filter-radius, #{$radius-md});
   transition: all 0.2s;
   text-transform: uppercase;
   letter-spacing: $letter-spacing-sm;
   font-size: $font-size-base;
+  cursor: pointer;
+  font-family: inherit;
 
   &:hover {
-    background: color.adjust($color-lario-light, $lightness: -8%);
-    box-shadow: 0 0 15px color.adjust($color-lario-light, $alpha: -0.6);
+    background: color.adjust($color-accent-dark, $lightness: -8%);
+    box-shadow: 0 0 15px color.adjust($color-accent-dark, $alpha: -0.6);
     transform: translateY(-1px);
   }
 }
@@ -235,11 +243,13 @@
   align-items: center;
   justify-content: center;
   padding: $spacing-sm;
-  border: $border-hairline solid color.adjust($color-white, $alpha: -0.8);
-  border-radius: $radius-md;
-  background: color.adjust($color-white, $alpha: -0.95);
+  border: $border-hairline solid color.adjust($color-silk-light, $alpha: -0.8);
+  border-radius: var(--route-filter-radius, #{$radius-md});
+  background: color.adjust($color-silk-light, $alpha: -0.95);
+  color: $color-silk-light;
+
   &:hover {
-    background: color.adjust($color-white, $alpha: -0.9);
+    background: color.adjust($color-silk-light, $alpha: -0.9);
   }
 }
 
@@ -252,15 +262,22 @@
   animation: fadeInUp 0.5s ease-out;
 }
 
+// Bezel greys derive from the silk neutral instead of raw hexes, so the TV
+// stays anchored to the palette.
 .tvBezel {
-  background: linear-gradient(145deg, #2a2a2a 0%, #1a1a1a 50%, #111 100%);
-  border-radius: $radius-lg;
+  background: linear-gradient(
+    145deg,
+    color.adjust($color-silk-dark, $lightness: 13%) 0%,
+    color.adjust($color-silk-dark, $lightness: 6%) 50%,
+    color.adjust($color-silk-dark, $lightness: 3%) 100%
+  );
+  border-radius: var(--route-card-radius, #{$radius-lg});
   padding: 28px 28px 52px;
   box-shadow:
-    0 0 0 2px #3a3a3a,
-    0 8px 60px rgba(0, 0, 0, 0.9),
-    inset 0 2px 4px rgba(255, 255, 255, 0.06),
-    inset 0 -2px 4px rgba(0, 0, 0, 0.5);
+    0 0 0 2px color.adjust($color-silk-dark, $lightness: 19%),
+    0 8px 60px rgba($color-black, 0.9),
+    inset 0 2px 4px color.adjust($color-silk-light, $alpha: -0.94),
+    inset 0 -2px 4px rgba($color-black, 0.5);
   position: relative;
 }
 
@@ -270,10 +287,10 @@
   padding-bottom: 62%;
   border-radius: $radius-sm;
   overflow: hidden;
-  background: #000;
+  background: $color-black;
   box-shadow:
-    inset 0 0 30px rgba(0, 0, 0, 0.9),
-    0 0 20px rgba(0, 200, 80, 0.04);
+    inset 0 0 30px rgba($color-black, 0.9),
+    0 0 20px color.adjust($color-secondary-dark, $alpha: -0.96);
 
   iframe {
     position: absolute;
@@ -290,8 +307,8 @@
     0deg,
     transparent,
     transparent 3px,
-    rgba(0, 0, 0, 0.12) 3px,
-    rgba(0, 0, 0, 0.12) 4px
+    rgba($color-black, 0.12) 3px,
+    rgba($color-black, 0.12) 4px
   );
   pointer-events: none;
   border-radius: $radius-sm;
@@ -302,7 +319,7 @@
   position: absolute;
   inset: 0;
   border-radius: $radius-sm;
-  background: radial-gradient(ellipse at center, transparent 55%, rgba(0, 0, 0, 0.55) 100%);
+  background: radial-gradient(ellipse at center, transparent 55%, rgba($color-black, 0.55) 100%);
   pointer-events: none;
   z-index: 3;
 }
@@ -334,8 +351,10 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #2d2d2d;
-  box-shadow: 0 0 0 2px #404040, inset 0 1px 2px rgba(0, 0, 0, 0.6);
+  background: color.adjust($color-silk-dark, $lightness: 14%);
+  box-shadow:
+    0 0 0 2px color.adjust($color-silk-dark, $lightness: 21%),
+    inset 0 1px 2px rgba($color-black, 0.6);
 }
 
 .tvOpenLink {

--- a/src/components/atoms/custom-cursor/CustomCursor.tsx
+++ b/src/components/atoms/custom-cursor/CustomCursor.tsx
@@ -6,9 +6,11 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import styles from "./CustomCursor.module.scss";
 
-// Magnetism only reads as "magnetic" on compact controls; on large surfaces
-// (e.g. full-width list rows) it just drags the whole block around and forces
-// the ink filter to re-run over the page every frame.
+// Magnetism (translating the hovered element) only reads as "magnetic" on
+// compact controls; on large surfaces (e.g. full-width list rows) it drags
+// the whole block around and forces the ink filter to re-run over the page
+// every frame. The blob envelope has no such cost, so it applies to every
+// interactive element regardless of size.
 const MAX_MAGNET_WIDTH = 320;
 const MAX_MAGNET_HEIGHT = 120;
 
@@ -134,17 +136,18 @@ export default function CustomCursor() {
         activeMagnetRef.current = entry;
         if (entry.eligible) {
           candidate.style.setProperty("will-change", "translate");
-          setEnvelope(envelopeFor(rect, entry.radius));
-        } else {
-          setEnvelope(null);
         }
+        setEnvelope(envelopeFor(rect, entry.radius));
       }
-
-      if (!entry.eligible) return pointer;
 
       const { rect } = entry;
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
+
+      // Large surfaces get the envelope but not the translate: the blob
+      // parks on their center while the element stays put.
+      if (!entry.eligible) return { x: centerX, y: centerY };
+
       const normalizedX = (e.clientX - centerX) / Math.max(rect.width, 1);
       const normalizedY = (e.clientY - centerY) / Math.max(rect.height, 1);
       const maxOffset = 10;
@@ -178,7 +181,7 @@ export default function CustomCursor() {
       // A click can swap the control's content (PLAY -> PAUSE), so re-measure
       // the enveloped rect once the DOM has settled, minus our own translate.
       const entry = activeMagnetRef.current;
-      if (!entry?.eligible) return;
+      if (!entry) return;
       requestAnimationFrame(() => {
         if (activeMagnetRef.current !== entry) return;
         const raw = entry.el.getBoundingClientRect();

--- a/src/components/organisms/Terminal/SnakeGame.module.scss
+++ b/src/components/organisms/Terminal/SnakeGame.module.scss
@@ -4,6 +4,8 @@
 .game {
   display: flex;
   flex-direction: column;
+  align-items: center; // grid centered in the terminal body
+  justify-content: center;
   gap: $spacing-xs;
   height: 100%;
   min-height: 0;
@@ -15,6 +17,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  width: 100%;
   color: var(--color-secondary);
   text-transform: uppercase;
   letter-spacing: $letter-spacing-md;

--- a/src/components/organisms/Terminal/Terminal.module.scss
+++ b/src/components/organisms/Terminal/Terminal.module.scss
@@ -249,6 +249,11 @@
     padding: $spacing-xs $spacing-md;
     min-height: $size-control-md;
     color: var(--color-text);
+    // Buttons don't inherit font: without this they fall back to the UA
+    // default and stick out from the rest of the terminal.
+    font-family: $font-family-mono;
+    font-size: $font-size-xs;
+    letter-spacing: $letter-spacing-md;
     cursor: pointer;
     transition: all 0.2s ease;
     opacity: 0.7;

--- a/src/components/organisms/Terminal/Terminal.tsx
+++ b/src/components/organisms/Terminal/Terminal.tsx
@@ -338,8 +338,12 @@ export default function Terminal({
             <SnakeGame
               onExit={(score) => {
                 setGameActive(false);
-                setHistory((prev) => [
+                // Input remounts on exit; hand focus back on desktop.
+                requestAnimationFrame(() => {
                   // eslint-disable-next-line max-lines
+                  if (shouldAutoFocus()) inputRef.current?.focus();
+                });
+                setHistory((prev) => [
                   ...prev,
                   {
                     command: "snake",
@@ -456,22 +460,28 @@ export default function Terminal({
           )}
         </div>
 
-        <TerminalQuickCommands
-          context={context}
-          onCommand={executeQuickCommand}
-        />
-        <TerminalInput
-          ref={inputRef}
-          value={input}
-          suggestion={suggestion}
-          context={context}
-          onChange={(v) => {
-            setInput(v);
-            if (v.length > 0) playType();
-          }}
-          onKeyDown={handleInputKeyDown}
-          onSubmit={submitCurrentInput}
-        />
+        {/* Hidden while the game runs: a focused input would swallow the
+            arrow keys (ArrowDown jumped to command history mid-game). */}
+        {!gameActive && (
+          <>
+            <TerminalQuickCommands
+              context={context}
+              onCommand={executeQuickCommand}
+            />
+            <TerminalInput
+              ref={inputRef}
+              value={input}
+              suggestion={suggestion}
+              context={context}
+              onChange={(v) => {
+                setInput(v);
+                if (v.length > 0) playType();
+              }}
+              onKeyDown={handleInputKeyDown}
+              onSubmit={submitCurrentInput}
+            />
+          </>
+        )}
       </div>
     </TerminalOverlay>
   );

--- a/src/components/templates/Layout/RightColumn.tsx
+++ b/src/components/templates/Layout/RightColumn.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Magnetic from "@/components/atoms/magnetic";
 import { usePathname } from "next/navigation";
 import SocialLinks from "./SocialLinks";
 import ThemeToggle from "./ThemeToggle";
@@ -15,9 +14,13 @@ export default function RightColumn() {
 
   return (
     <aside className={`${styles.rightColumn} ${isLab ? styles.autoHide : ""}`}>
-      <Magnetic>
+      {/* No Magnetic wrapper (it suppresses the global blob envelope), but
+          the plain div must stay: the rail is pointer-events: none with a
+          `> *` re-enable, and Button's `all: unset` would inherit the rail's
+          none if the button were the direct child. */}
+      <div>
         <ThemeToggle />
-      </Magnetic>
+      </div>
 
       <div className={styles.divider}></div>
 


### PR DESCRIPTION
## What

Design-system coverage and interaction fixes reported in review.

**Time machine under the design system.** The page kept its fixed-dark CRT scene but every raw value is now a token: glitch chromatic aberration uses secondary/accent instead of cyan/magenta, TV bezel greys derive from the silk neutral, the CRT glow comes from the secondary token instead of a random green, and card/badge/CTA corners use the squircle radius vars. The primary action mirrors the site CTA (accent background, squircle, inherited mono font) and is now a proper button style-wise (cursor, font).

**Terminal quick-command chips.** They never declared a font-family, so they rendered in the UA default. Now mono stack, xs size, tracking to match the terminal.

**Snake.** The input and chips unmount while the game runs, so arrows can no longer land in the command input (ArrowDown used to jump into command history mid-game); focus is handed back to the input when the game exits. The board is centered in the terminal body instead of hugging the left edge.

**Envelope gaps.**
- Theme toggle: its local Magnetic wrapper suppressed the global cursor system, so it never got the blob envelope. Wrapper removed; a plain div shield stays because Button's `all: unset` would inherit the rail's `pointer-events: none` (found via elementFromPoint - direct-child buttons of the rails were unreachable).
- Project rows (and any large interactive surface) now get the envelope too: the blob stretches over the row and the difference blend performs the inversion. The old CSS hover inversion remains as a coarse-pointer fallback and as focus-visible for keyboard users. Magnetism translate stays gated to compact controls (that was the ink-filter perf issue).

## Verification

Headless Chromium against the dev server:

- /lab row hover: blob 1316x101 over the 1304x89 row, `data-enveloped=true`, row background stays transparent (blob does the inversion), no inline translate on the row (screenshot-verified inverted row)
- theme toggle hover on the homepage: enveloped 166x56 around the 154x44 pill; ancestor-chain probe confirms the button receives pointer events again
- terminal chips compute to Geist Mono 10px
- snake: input absent during play, focus stays on body, ArrowDown/ArrowLeft steer without leaving the game, ESC exits and the prompt returns; board centered (screenshot)
- /time-machine renders in palette colors with squircle corners (screenshot)
- 120/120 jest tests, eslint and production build clean

Generated with [Claude Code](https://claude.com/claude-code)
