### PR TITLE
Admit wide CTAs to cursor magnetism

### DIFF
--- a/src/components/atoms/custom-cursor/CustomCursor.tsx
+++ b/src/components/atoms/custom-cursor/CustomCursor.tsx
@@ -7,11 +7,12 @@ import { useEffect, useRef, useState } from "react";
 import styles from "./CustomCursor.module.scss";
 
 // Magnetism (translating the hovered element) only reads as "magnetic" on
-// compact controls; on large surfaces (e.g. full-width list rows) it drags
-// the whole block around and forces the ink filter to re-run over the page
-// every frame. The blob envelope has no such cost, so it applies to every
-// interactive element regardless of size.
-const MAX_MAGNET_WIDTH = 320;
+// controls, not on large surfaces: full-width list rows dragged around force
+// the ink filter to re-run over the page every frame. The cap must still
+// admit wide CTAs (e.g. the ~470px time-machine action) — only row-scale
+// elements are excluded. The blob envelope has no such cost, so it applies
+// to every interactive element regardless of size.
+const MAX_MAGNET_WIDTH = 480;
 const MAX_MAGNET_HEIGHT = 120;
 
 // Keep in sync with $size-cursor-ring in the SCSS variables.


### PR DESCRIPTION
The 320px size gate on global magnetism (added to keep full-width /lab rows from dragging the ink filter) also excluded page-level CTAs - the 472px time-machine action did not react to the mouse at all. The cap is now 480px.

Verified with headless Chromium: the time-machine CTA translates with the pointer (distinct offsets at opposite corners) and keeps the blob envelope; no element on /lab or /about falls in the newly admitted 320-480px range, and project rows still get no inline translate. 120/120 tests, lint and build clean.

Generated with [Claude Code](https://claude.com/claude-code)