### PR TITLE
Accept demo password, remove click and redirect latency

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 import { useTheme } from '@/context/ThemeContext'
 import styles from './page.module.scss'
 
-const DEMO_PASSWORD = 'wubbalubbadubdub'
+import { DEMO_PASSWORD } from '@/lib/demo'
 
 export default function AdminLoginPage() {
   const router = useRouter()

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -6,6 +6,11 @@ export async function POST(request: Request) {
   if (!checkPassword(password)) {
     return NextResponse.json({ error: 'Invalid password' }, { status: 401 })
   }
-  await setSession()
+  if (!(await setSession())) {
+    return NextResponse.json(
+      { error: 'Auth not configured (missing SESSION_SECRET)' },
+      { status: 503 },
+    )
+  }
   return NextResponse.json({ success: true })
 }

--- a/src/app/lab/[slug]/BackLink.tsx
+++ b/src/app/lab/[slug]/BackLink.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import styles from "./ProjectDetail.module.scss";
+
+/**
+ * Back link that preserves the /lab filter from the query string.
+ * Client-side on purpose: reading searchParams in the server page would opt
+ * the whole route out of static generation, turning every card click into an
+ * on-demand server render.
+ */
+export default function BackLink() {
+  const filter = useSearchParams().get("filter");
+  const backHref = filter
+    ? `/lab?filter=${encodeURIComponent(filter)}`
+    : "/lab";
+
+  return (
+    <Link href={backHref} className={styles.backLink}>
+      <ArrowLeft size={14} />
+      Work
+    </Link>
+  );
+}

--- a/src/app/lab/[slug]/page.tsx
+++ b/src/app/lab/[slug]/page.tsx
@@ -5,6 +5,8 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import BackLink from "./BackLink";
 import styles from "./ProjectDetail.module.scss";
 
 export async function generateStaticParams() {
@@ -39,19 +41,17 @@ export async function generateMetadata({
   };
 }
 
+// No `searchParams` here: awaiting it would make the route dynamic (a server
+// render per click). The filter-aware back link reads it client-side instead.
 export default async function ProjectPage({
   params,
-  searchParams,
 }: {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ filter?: string }>;
 }) {
   const { slug } = await params;
-  const { filter } = await searchParams;
   const project = PROJECTS.find((p) => p.id === decodeURIComponent(slug));
   if (!project) notFound();
 
-  const backHref = filter ? `/lab?filter=${encodeURIComponent(filter)}` : "/lab";
   const stack = project.stack && project.stack.length > 0 ? project.stack : project.tags;
 
   const mediaFrames = Array.from(
@@ -90,10 +90,16 @@ export default async function ProjectPage({
 
   return (
     <main className={styles.container}>
-      <Link href={backHref} className={styles.backLink}>
-        <ArrowLeft size={14} />
-        Work
-      </Link>
+      <Suspense
+        fallback={
+          <Link href="/lab" className={styles.backLink}>
+            <ArrowLeft size={14} />
+            Work
+          </Link>
+        }
+      >
+        <BackLink />
+      </Suspense>
 
       <header className={styles.header}>
         <div className={styles.meta}>

--- a/src/app/lab/page.tsx
+++ b/src/app/lab/page.tsx
@@ -4,6 +4,7 @@ import { PROJECTS } from "@/data/projects";
 import type { Project } from "@/types/project";
 import Text from "@/components/atoms/text";
 import { AnimatePresence, motion } from "framer-motion";
+import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import styles from "./page.module.scss";
@@ -49,11 +50,13 @@ export default function Lab() {
     router.replace(q ? `${pathname}?${q}` : pathname, { scroll: false });
   };
 
-  const go = (project: Project) => {
+  // Real links instead of router.push-on-click: the detail pages are static,
+  // so Link prefetches them in-viewport and navigation is instant.
+  const hrefFor = (project: Project) => {
     const p = new URLSearchParams();
     if (filter !== "all") p.set("filter", filter);
     const q = p.toString();
-    router.push(q ? `/lab/${project.id}?${q}` : `/lab/${project.id}`);
+    return q ? `/lab/${project.id}?${q}` : `/lab/${project.id}`;
   };
 
   const live = LIVE.filter((p) => matchesGroup(p, filter));
@@ -99,11 +102,11 @@ export default function Lab() {
       >
         <div className={styles.projectList} role="list">
           {live.map((project, i) => (
-            <button
+            <Link
               key={project.id}
               role="listitem"
               className={styles.projectRow}
-              onClick={() => go(project)}
+              href={hrefFor(project)}
             >
               <span className={styles.rowNum}>{String(i + 1).padStart(2, "0")}</span>
               <div className={styles.rowMain}>
@@ -117,7 +120,7 @@ export default function Lab() {
                     to Apple Color Emoji when the webfont lacks the glyph */}
                 {project.status === "live" && <span className={styles.rowArrow}>{"↗︎"}</span>}
               </div>
-            </button>
+            </Link>
           ))}
         </div>
 
@@ -146,11 +149,11 @@ export default function Lab() {
                   role="list"
                 >
                   {archived.map((project, i) => (
-                    <button
+                    <Link
                       key={project.id}
                       role="listitem"
                       className={`${styles.projectRow} ${styles.archivedRow}`}
-                      onClick={() => go(project)}
+                      href={hrefFor(project)}
                     >
                       <span className={styles.rowNum}>{String(i + 1).padStart(2, "0")}</span>
                       <div className={styles.rowMain}>
@@ -161,7 +164,7 @@ export default function Lab() {
                         <span className={styles.rowCategory}>{project.category}</span>
                         <span className={styles.rowYear}>{project.year}</span>
                       </div>
-                    </button>
+                    </Link>
                   ))}
                 </motion.div>
               )}

--- a/src/hooks/terminal/useSiteCommands.ts
+++ b/src/hooks/terminal/useSiteCommands.ts
@@ -15,7 +15,7 @@ type SiteCommandResult = {
 };
 
 type UseSiteCommandsOptions = {
-  router: { push: (href: string) => void };
+  router: { push: (href: string) => void; prefetch: (href: string) => void };
   toggleTheme: () => void;
   playLightOn: () => void;
   playError: () => void;
@@ -84,20 +84,25 @@ export function useSiteCommands({
         case "lab":
         case "experiments":
           outputs = [{ type: "success", content: "Accessing The Lab..." }];
-          setTimeout(() => { router.push("/lab"); setIsOpen(false); }, 800);
+          // Prefetch immediately so the route loads while the message shows;
+          // the pause is only a readable beat, not masking a fetch.
+          router.prefetch("/lab");
+          setTimeout(() => { router.push("/lab"); setIsOpen(false); }, 400);
           break;
 
         case "home":
         case "back":
           outputs = [{ type: "success", content: "Returning Home..." }];
-          setTimeout(() => { router.push("/"); setIsOpen(false); }, 800);
+          router.prefetch("/");
+          setTimeout(() => { router.push("/"); setIsOpen(false); }, 400);
           break;
 
         case "about":
         case "chi":
         case "me":
           outputs = [{ type: "success", content: "About Ivan Del Fatti..." }];
-          setTimeout(() => { router.push("/about"); setIsOpen(false); }, 800);
+          router.prefetch("/about");
+          setTimeout(() => { router.push("/about"); setIsOpen(false); }, 400);
           break;
 
         case "clear":
@@ -116,10 +121,14 @@ export function useSiteCommands({
         case "time":
         case "flux":
           outputs = [{ type: "success", content: "Time Machine..." }];
-          setTimeout(() => { router.push("/time-machine"); setIsOpen(false); }, 800);
+          router.prefetch("/time-machine");
+          setTimeout(() => { router.push("/time-machine"); setIsOpen(false); }, 400);
           break;
 
         case "admin": {
+          // Prefetch before the auth round-trip so the dashboard loads in
+          // parallel with the /api/auth/me call instead of after it.
+          router.prefetch("/admin");
           const user = await getAuthUser();
           outputs = user?.email
             ? [
@@ -131,7 +140,7 @@ export function useSiteCommands({
                 { type: "success", content: "→ /admin" },
                 { type: "text", content: "demo: admin@idf.dev / wubbalubbadubdub" },
               ];
-          setTimeout(() => { router.push("/admin"); setIsOpen(false); }, 900);
+          setTimeout(() => { router.push("/admin"); setIsOpen(false); }, 400);
           break;
         }
 
@@ -144,7 +153,7 @@ export function useSiteCommands({
               { type: "system", content: `Signing out ${logoutUser.email}...` },
               { type: "success", content: "Session terminated." },
             ];
-            setTimeout(async () => { await signOut(); setIsOpen(false); }, 800);
+            setTimeout(async () => { await signOut(); setIsOpen(false); }, 400);
           }
           break;
         }
@@ -238,7 +247,8 @@ export function useSiteCommands({
             break;
           }
           outputs = [{ type: "success", content: `Opening ${target.title}...` }];
-          setTimeout(() => { router.push(`/lab/${target.id}`); setIsOpen(false); }, 450);
+          router.prefetch(`/lab/${target.id}`);
+          setTimeout(() => { router.push(`/lab/${target.id}`); setIsOpen(false); }, 400);
           break;
         }
 

--- a/src/hooks/terminal/useTerminalCommands.ts
+++ b/src/hooks/terminal/useTerminalCommands.ts
@@ -9,7 +9,7 @@ import { useAdminCommands } from "./useAdminCommands";
 import { useSiteCommands } from "./useSiteCommands";
 
 type UseTerminalCommandsOptions = {
-  router: { push: (href: string) => void };
+  router: { push: (href: string) => void; prefetch: (href: string) => void };
   toggleTheme: () => void;
   playLightOn: () => void;
   playError: () => void;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers'
+import { DEMO_PASSWORD } from './demo'
 import {
   SESSION_COOKIE,
   SESSION_TTL_SECONDS,
@@ -16,9 +17,11 @@ export async function getUser() {
   return null
 }
 
-export async function setSession() {
+export async function setSession(): Promise<boolean> {
   const token = await createSessionToken()
-  if (!token) return
+  // No signing secret configured -> report it so the login route can fail
+  // loudly instead of "succeeding" without ever setting a cookie.
+  if (!token) return false
   const cookieStore = await cookies()
   cookieStore.set(SESSION_COOKIE, token, {
     httpOnly: true,
@@ -27,6 +30,7 @@ export async function setSession() {
     path: '/',
     maxAge: SESSION_TTL_SECONDS,
   })
+  return true
 }
 
 export async function clearSession() {
@@ -35,8 +39,11 @@ export async function clearSession() {
 }
 
 export function checkPassword(password: string) {
-  const expected = process.env.ADMIN_PASSWORD
-  // No password configured -> admin login is disabled (no baked-in fallback).
-  if (!expected) return false
-  return timingSafeEqual(password, expected)
+  const admin = process.env.ADMIN_PASSWORD
+  if (admin && timingSafeEqual(password, admin)) return true
+  // The public demo credential the login page advertises. Safe to accept:
+  // the admin API is a mock, nothing a demo session does persists. Sessions
+  // still need a signing secret (SESSION_SECRET or ADMIN_PASSWORD) to exist.
+  const demo = process.env.DEMO_PASSWORD || DEMO_PASSWORD
+  return timingSafeEqual(password, demo)
 }

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -1,0 +1,5 @@
+// Public demo credential ("Morty-level access"), advertised in the admin
+// login page and the terminal. Not a secret: the admin API is a mock (writes
+// echo back without persisting), so demo sessions can't touch real data.
+// Overridable via DEMO_PASSWORD on the server side.
+export const DEMO_PASSWORD = "wubbalubbadubdub";


### PR DESCRIPTION
## What

Two user-facing bugs: the advertised demo credentials never worked, and clicks/redirects felt seconds slow.

**Demo login.** The login page and the terminal advertise the Morty-level demo password, but `checkPassword` only compared against `ADMIN_PASSWORD`, so demo logins always returned Invalid password. The demo credential now lives in `src/lib/demo.ts` (single source for the login page and the server), is accepted by `checkPassword` (overridable via `DEMO_PASSWORD` env), and is safe by construction: the admin projects API is a mock that echoes writes without persisting, so a demo session cannot touch real data - "changes self-destruct" was already literally true. The login route also returns 503 when no session signing secret is configured, instead of reporting success without ever setting a cookie.

**Card click latency.** `/lab/[slug]` had `generateStaticParams` but awaited `searchParams` (used only for the filter-aware back link), which opts the route into dynamic rendering - every card click paid an on-demand serverless render, cold starts included. The back link moved to a small client component reading the query string, the route now prerenders (build output flipped from dynamic to static), and the list rows became real `Link`s so detail pages prefetch in-viewport. Clicks are now local navigations.

**Terminal redirect latency.** Navigation commands slept 700-900ms before `router.push`, and `admin` additionally awaited `/api/auth/me` first. Target routes are now prefetched the moment the command runs (for `admin`, in parallel with the auth check) and the theatrical pause is 400ms.

## Verification

Headless against the dev server (`SESSION_SECRET` set):

- POST `/api/auth/login` with the demo password: 200 + session cookie; the cookie opens `/admin` (200); wrong password 401; no cookie redirects 307 to `/admin/login`
- build output shows `● /lab/[slug]` (prerendered) - it was `ƒ` before
- /lab rows render as anchors with the filter in the href; clicking navigates to `/lab/gabberg-icard?filter=code`, back link returns to `/lab?filter=code`
- 120/120 jest tests, eslint and production build clean

Generated with [Claude Code](https://claude.com/claude-code)
