### PR TITLE
Zoomable gallery lightbox and experiment markers in the work list

### DIFF
--- a/src/app/lab/[slug]/ProjectDetail.module.scss
+++ b/src/app/lab/[slug]/ProjectDetail.module.scss
@@ -199,6 +199,46 @@
   background: var(--color-bg);
 }
 
+// Frame-as-button: neutralize UA button chrome without `all: unset`, which
+// would also wipe the .mediaFrame declarations sharing the element.
+.mediaFrameClickable {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  display: block;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: $border-base solid var(--color-accent);
+    outline-offset: calc(-1 * #{$border-base});
+  }
+
+  &:hover .mediaZoomHint {
+    opacity: 1;
+  }
+}
+
+.mediaZoomHint {
+  position: absolute;
+  right: $spacing-sm;
+  bottom: $spacing-sm;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: $font-family-mono;
+  font-size: $font-size-md;
+  line-height: 1;
+  color: var(--color-bg);
+  background: color-mix(in srgb, var(--color-text) 75%, transparent);
+  border-radius: var(--route-filter-radius, #{$radius-md});
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+}
+
 .mediaFrameHero {
   grid-column: 1 / -1;
 }

--- a/src/app/lab/[slug]/ProjectMedia.tsx
+++ b/src/app/lab/[slug]/ProjectMedia.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Lightbox from "@/components/molecules/lightbox";
+import Image from "next/image";
+import { useState } from "react";
+import styles from "./ProjectDetail.module.scss";
+
+interface ProjectMediaProps {
+  frames: string[];
+  title: string;
+  fit: "cover" | "contain";
+}
+
+/**
+ * Media grid for the project detail page. Every frame opens the zoomable
+ * Lightbox. Client-side only for the viewer state; the grid markup matches
+ * the previous server-rendered one.
+ */
+export default function ProjectMedia({ frames, title, fit }: ProjectMediaProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  if (frames.length === 0) return null;
+
+  return (
+    <>
+      <div className={`${styles.media} ${frames.length > 1 ? styles.mediaMulti : ""}`}>
+        {frames.map((src, i) => (
+          <button
+            key={src}
+            type="button"
+            // Opted out of the global cursor envelope: a difference-blend blob
+            // over a photo reads as a broken negative, not as a highlight.
+            data-local-magnetic="true"
+            className={`${styles.mediaFrame} ${styles.mediaFrameClickable} ${
+              i === 0 && frames.length > 1 ? styles.mediaFrameHero : ""
+            }`}
+            onClick={() => setOpenIndex(i)}
+            aria-label={`Open ${title} frame ${i + 1} in the viewer`}
+          >
+            <Image
+              src={src}
+              alt={`${title} — frame ${i + 1}`}
+              fill
+              className={`${styles.mediaImg} ${
+                fit === "cover" ? styles.mediaCover : styles.mediaContain
+              }`}
+              sizes={i === 0 ? "(max-width: 768px) 100vw, 860px" : "(max-width: 768px) 50vw, 430px"}
+              priority={i === 0}
+            />
+            <span className={styles.mediaZoomHint} aria-hidden="true">
+              +
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {openIndex !== null && (
+        <Lightbox
+          images={frames}
+          title={title}
+          index={openIndex}
+          onNavigate={setOpenIndex}
+          onClose={() => setOpenIndex(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/lab/[slug]/page.tsx
+++ b/src/app/lab/[slug]/page.tsx
@@ -2,11 +2,11 @@ import Text from "@/components/atoms/text";
 import { PROJECTS } from "@/data/projects";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import BackLink from "./BackLink";
+import ProjectMedia from "./ProjectMedia";
 import styles from "./ProjectDetail.module.scss";
 
 export async function generateStaticParams() {
@@ -129,29 +129,7 @@ export default async function ProjectPage({
         </section>
       )}
 
-      {mediaFrames.length > 0 && (
-        <div className={`${styles.media} ${mediaFrames.length > 1 ? styles.mediaMulti : ""}`}>
-          {mediaFrames.map((src, i) => (
-            <div
-              key={src}
-              className={`${styles.mediaFrame} ${i === 0 && mediaFrames.length > 1 ? styles.mediaFrameHero : ""}`}
-            >
-              <Image
-                src={src}
-                alt={`${project.title} — frame ${i + 1}`}
-                fill
-                className={`${styles.mediaImg} ${
-                  mediaFit === "cover"
-                    ? styles.mediaCover
-                    : styles.mediaContain
-                }`}
-                sizes={i === 0 ? "(max-width: 768px) 100vw, 860px" : "(max-width: 768px) 50vw, 430px"}
-                priority={i === 0}
-              />
-            </div>
-          ))}
-        </div>
-      )}
+      <ProjectMedia frames={mediaFrames} title={project.title} fit={mediaFit} />
 
       <footer className={styles.footer}>
         <div className={styles.stack}>

--- a/src/app/lab/page.module.scss
+++ b/src/app/lab/page.module.scss
@@ -255,6 +255,26 @@
   }
 }
 
+// Experiments sit in the same list as product work, marked by a small
+// accent diamond and a tinted category label — merged, but distinguishable.
+.projectRow[data-kind="experiment"] {
+  .rowTitle::before {
+    content: "";
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: $spacing-xs;
+    margin-bottom: 1px;
+    background: var(--color-accent);
+    rotate: 45deg;
+  }
+
+  .rowCategory {
+    color: var(--color-accent);
+    opacity: 0.75;
+  }
+}
+
 .rowDesc {
   font-family: $font-family-mono;
   font-size: $font-size-xs;

--- a/src/app/lab/page.tsx
+++ b/src/app/lab/page.tsx
@@ -59,6 +59,11 @@ export default function Lab() {
     return q ? `/lab/${project.id}?${q}` : `/lab/${project.id}`;
   };
 
+  // Experiments live in the same list as client/product work but carry a
+  // subtle visual marker so the two read differently at a glance.
+  const kindOf = (p: Project) =>
+    matchesGroup(p, "lab") ? "experiment" : undefined;
+
   const live = LIVE.filter((p) => matchesGroup(p, filter));
   const archived = ARCHIVED.filter((p) => matchesGroup(p, filter));
 
@@ -106,6 +111,7 @@ export default function Lab() {
               key={project.id}
               role="listitem"
               className={styles.projectRow}
+              data-kind={kindOf(project)}
               href={hrefFor(project)}
             >
               <span className={styles.rowNum}>{String(i + 1).padStart(2, "0")}</span>
@@ -153,6 +159,7 @@ export default function Lab() {
                       key={project.id}
                       role="listitem"
                       className={`${styles.projectRow} ${styles.archivedRow}`}
+                      data-kind={kindOf(project)}
                       href={hrefFor(project)}
                     >
                       <span className={styles.rowNum}>{String(i + 1).padStart(2, "0")}</span>

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,4 +1,5 @@
 // Molecules barrel exports
 export { default as AudioPrompt } from './audio-prompt';
 export { default as GalleryViewer } from './gallery-viewer';
+export { default as Lightbox } from './lightbox';
 export { default as ParticleLogo } from './particle-logo';

--- a/src/components/molecules/lightbox/Lightbox.module.scss
+++ b/src/components/molecules/lightbox/Lightbox.module.scss
@@ -1,0 +1,106 @@
+@use "@/styles/variables" as *;
+@use "@/styles/mixins" as *;
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 6000; // above the chrome, below the custom cursor
+  display: flex;
+  flex-direction: column;
+  background: rgba($color-silk-dark, 0.94);
+  backdrop-filter: blur($blur-sm);
+}
+
+.topBar,
+.bottomBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-md;
+  padding: $spacing-md $spacing-lg;
+  flex-shrink: 0;
+}
+
+.bottomBar {
+  justify-content: center;
+  gap: $spacing-lg;
+}
+
+.frameName {
+  font-family: $font-family-mono;
+  font-size: $font-size-xs;
+  text-transform: uppercase;
+  letter-spacing: $letter-spacing-xl;
+  color: $color-silk-light;
+  opacity: 0.6;
+}
+
+.closeBtn,
+.navBtn {
+  background: transparent;
+  border: $border-hairline solid color-mix(in srgb, #{$color-silk-light} 35%, transparent);
+  border-radius: var(--route-filter-radius, #{$radius-md});
+  color: $color-silk-light;
+  font-family: $font-family-mono;
+  font-size: $font-size-xs;
+  letter-spacing: $letter-spacing-md;
+  padding: $spacing-xs $spacing-md;
+  min-height: $touch-target-min;
+  min-width: $touch-target-min;
+  cursor: pointer;
+  opacity: 0.75;
+  transition: opacity 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    opacity: 1;
+    border-color: $color-silk-light;
+  }
+
+  &:focus-visible {
+    outline: $border-base solid var(--color-accent);
+    outline-offset: $border-base;
+  }
+}
+
+.counter {
+  font-family: $font-family-mono;
+  font-size: $font-size-xs;
+  letter-spacing: $letter-spacing-xl;
+  color: $color-silk-light;
+  opacity: 0.6;
+  white-space: nowrap;
+}
+
+.stage {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  touch-action: none; // pinch and pan belong to the viewer, not the page
+  cursor: zoom-in;
+
+  &[data-zoomed] {
+    cursor: grab;
+  }
+
+  &[data-dragging] {
+    cursor: grabbing;
+  }
+}
+
+.canvas {
+  position: absolute;
+  inset: 0;
+  transition: transform 0.18s ease-out;
+  will-change: transform;
+
+  .stage[data-dragging] & {
+    transition: none; // 1:1 while dragging, eased for wheel/dblclick steps
+  }
+}
+
+.image {
+  object-fit: contain;
+  user-select: none;
+  -webkit-user-drag: none;
+}

--- a/src/components/molecules/lightbox/Lightbox.tsx
+++ b/src/components/molecules/lightbox/Lightbox.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import Text from "@/components/atoms/text";
+import Image from "next/image";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import styles from "./Lightbox.module.scss";
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 4;
+const DBLCLICK_ZOOM = 2.5;
+
+interface LightboxProps {
+  images: string[];
+  title: string;
+  index: number;
+  onNavigate: (index: number) => void;
+  onClose: () => void;
+}
+
+/**
+ * Fullscreen image viewer with zoom and pan.
+ * Wheel / pinch to zoom (1x-4x), drag to pan while zoomed, double click to
+ * toggle, arrows to navigate, Escape or backdrop click to close.
+ * Rendered in a portal so transformed route-transition ancestors cannot break
+ * the fixed positioning.
+ */
+export default function Lightbox({
+  images,
+  title,
+  index,
+  onNavigate,
+  onClose,
+}: LightboxProps) {
+  const [zoom, setZoom] = useState(MIN_ZOOM);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+
+  const stageRef = useRef<HTMLDivElement>(null);
+  const pointersRef = useRef(new Map<number, { x: number; y: number }>());
+  const pinchRef = useRef<{ dist: number; zoom: number } | null>(null);
+
+  const zoomRef = useRef(zoom);
+  useEffect(() => {
+    zoomRef.current = zoom;
+  }, [zoom]);
+
+  const clampOffset = useCallback((next: { x: number; y: number }, z: number) => {
+    // Keep the image from being dragged fully out of the stage.
+    const stage = stageRef.current;
+    const maxX = stage ? ((z - 1) * stage.clientWidth) / 2 : 0;
+    const maxY = stage ? ((z - 1) * stage.clientHeight) / 2 : 0;
+    return {
+      x: Math.max(-maxX, Math.min(maxX, next.x)),
+      y: Math.max(-maxY, Math.min(maxY, next.y)),
+    };
+  }, []);
+
+  const applyZoom = useCallback(
+    (next: number) => {
+      const z = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, next));
+      setZoom(z);
+      setOffset((prev) => (z === MIN_ZOOM ? { x: 0, y: 0 } : clampOffset(prev, z)));
+    },
+    [clampOffset],
+  );
+
+  const resetView = useCallback(() => {
+    setZoom(MIN_ZOOM);
+    setOffset({ x: 0, y: 0 });
+  }, []);
+
+  // Fresh frame, fresh view (derived-state reset during render, no effect).
+  const [lastIndex, setLastIndex] = useState(index);
+  if (lastIndex !== index) {
+    setLastIndex(index);
+    setZoom(MIN_ZOOM);
+    setOffset({ x: 0, y: 0 });
+  }
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.stopPropagation(); onClose(); }
+      else if (e.key === "ArrowLeft" && images.length > 1)
+        onNavigate((index - 1 + images.length) % images.length);
+      else if (e.key === "ArrowRight" && images.length > 1)
+        onNavigate((index + 1) % images.length);
+      else if (e.key === "+" || e.key === "=") applyZoom(zoomRef.current * 1.25);
+      else if (e.key === "-") applyZoom(zoomRef.current / 1.25);
+      else return;
+      e.preventDefault();
+    };
+    // Capture phase so the terminal's global Escape handling never races us.
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true });
+  }, [images.length, index, onNavigate, onClose, applyZoom]);
+
+  // Native wheel listener: React's synthetic one can be passive, and the
+  // zoom must preventDefault to keep the page from scrolling underneath.
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      applyZoom(zoomRef.current * (e.deltaY < 0 ? 1.15 : 1 / 1.15));
+    };
+    stage.addEventListener("wheel", onWheel, { passive: false });
+    return () => stage.removeEventListener("wheel", onWheel);
+  }, [applyZoom]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pointersRef.current.size === 2) {
+      const [a, b] = [...pointersRef.current.values()];
+      pinchRef.current = { dist: Math.hypot(a.x - b.x, a.y - b.y), zoom: zoomRef.current };
+    } else if (zoomRef.current > MIN_ZOOM) {
+      setDragging(true);
+    }
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const prev = pointersRef.current.get(e.pointerId);
+    if (!prev) return;
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (pointersRef.current.size === 2 && pinchRef.current) {
+      const [a, b] = [...pointersRef.current.values()];
+      const dist = Math.hypot(a.x - b.x, a.y - b.y);
+      applyZoom((pinchRef.current.zoom * dist) / Math.max(pinchRef.current.dist, 1));
+    } else if (pointersRef.current.size === 1 && zoomRef.current > MIN_ZOOM) {
+      const dx = e.clientX - prev.x;
+      const dy = e.clientY - prev.y;
+      setOffset((o) => clampOffset({ x: o.x + dx, y: o.y + dy }, zoomRef.current));
+    }
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    pointersRef.current.delete(e.pointerId);
+    if (pointersRef.current.size < 2) pinchRef.current = null;
+    if (pointersRef.current.size === 0) setDragging(false);
+  };
+
+  const onDoubleClick = () => {
+    if (zoomRef.current > MIN_ZOOM) resetView();
+    else applyZoom(DBLCLICK_ZOOM);
+  };
+
+  const frameName =
+    images[index]?.split("/").pop()?.split(".")[0]?.replace(/-/g, " ") ?? title;
+
+  return createPortal(
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${title} gallery`}
+      onClick={onClose}
+    >
+      <div className={styles.topBar} onClick={(e) => e.stopPropagation()}>
+        <Text as="span" variant="label" className={styles.frameName}>
+          {frameName}
+        </Text>
+        <button className={styles.closeBtn} onClick={onClose} aria-label="Close viewer">
+          ESC ×
+        </button>
+      </div>
+
+      <div
+        ref={stageRef}
+        className={styles.stage}
+        data-dragging={dragging || undefined}
+        data-zoomed={zoom > MIN_ZOOM || undefined}
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        onDoubleClick={onDoubleClick}
+      >
+        <div
+          className={styles.canvas}
+          style={{ transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})` }}
+        >
+          <Image
+            src={images[index]}
+            alt={`${title} - frame ${index + 1}`}
+            fill
+            sizes="100vw"
+            className={styles.image}
+            priority
+            draggable={false}
+          />
+        </div>
+      </div>
+
+      <div className={styles.bottomBar} onClick={(e) => e.stopPropagation()}>
+        {images.length > 1 ? (
+          <>
+            <button
+              className={styles.navBtn}
+              onClick={() => onNavigate((index - 1 + images.length) % images.length)}
+              aria-label="Previous image"
+            >
+              ←
+            </button>
+            <Text as="span" variant="label" className={styles.counter}>
+              {String(index + 1).padStart(2, "0")} / {String(images.length).padStart(2, "0")}
+            </Text>
+            <button
+              className={styles.navBtn}
+              onClick={() => onNavigate((index + 1) % images.length)}
+              aria-label="Next image"
+            >
+              →
+            </button>
+          </>
+        ) : (
+          <Text as="span" variant="label" className={styles.counter}>
+            scroll to zoom · drag to pan
+          </Text>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/molecules/lightbox/index.ts
+++ b/src/components/molecules/lightbox/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Lightbox";


### PR DESCRIPTION
## What

**Zoomable gallery.** The media frames on project detail pages now open a fullscreen Lightbox (new molecule):

- wheel / pinch to zoom (1x-4x), pan offset clamped so the image never leaves the stage
- drag to pan while zoomed (1:1, no easing mid-drag), double click toggles 1x/2.5x
- arrow keys / buttons navigate frames, Escape or backdrop click closes
- portal-rendered so the route-transition wrapper's transform cannot break the fixed overlay; Escape is handled in the capture phase so the terminal shortcut never races it
- a "+" hint appears on frame hover; the frames opt out of the cursor blob envelope (`data-local-magnetic`) because a difference-blend inversion over a photo reads as broken, not as a highlight

**Experiments in the work list.** Kept merged with product work (the filter system already covers both) but now visually distinguishable: EXPERIMENT/CODEPEN rows carry a small accent diamond before the title and an accent-tinted category label. Adding new experiments stays the same flow: an entry in `src/data/projects.ts` with one of those categories.

## Verification

Headless Chromium on the dev server:

- /lab rows report `data-kind` correctly (DEV/VSCODE/CREATIVE/MAKER -> project, CODEPEN -> experiment) and the accent diamonds render (screenshot)
- lightbox opens from a frame click, wheel zooms to 1.15, drag pans to exactly the clamp bound (-108, -56 at that zoom), double click resets to 1x
- ArrowRight advances the counter to 02/02, Escape closes the dialog
- /lab/[slug] still prerenders (static), 120/120 jest tests, eslint and production build clean

Generated with [Claude Code](https://claude.com/claude-code)
