### PR TITLE
feat: contextual cursor glyph (+/-) and squircle archive toggle

### DIFF
--- a/src/__tests__/components/CustomCursor.test.tsx
+++ b/src/__tests__/components/CustomCursor.test.tsx
@@ -28,11 +28,11 @@ describe('CustomCursor', () => {
     });
   });
 
-  it('renders two cursor div elements', async () => {
+  it('renders the dot, glyph, and blob cursor elements', async () => {
     const { container } = render(<CustomCursor />);
     await waitFor(() => {
       const cursorEls = container.querySelectorAll('[class*="cursor"]');
-      expect(cursorEls.length).toBe(2);
+      expect(cursorEls.length).toBe(3);
     });
   });
 });

--- a/src/app/lab/[slug]/ProjectDetail.module.scss
+++ b/src/app/lab/[slug]/ProjectDetail.module.scss
@@ -213,30 +213,6 @@
     outline: $border-base solid var(--color-accent);
     outline-offset: calc(-1 * #{$border-base});
   }
-
-  &:hover .mediaZoomHint {
-    opacity: 1;
-  }
-}
-
-.mediaZoomHint {
-  position: absolute;
-  right: $spacing-sm;
-  bottom: $spacing-sm;
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: $font-family-mono;
-  font-size: $font-size-md;
-  line-height: 1;
-  color: var(--color-bg);
-  background: color-mix(in srgb, var(--color-text) 75%, transparent);
-  border-radius: var(--route-filter-radius, #{$radius-md});
-  opacity: 0;
-  transition: opacity 0.15s ease;
-  pointer-events: none;
 }
 
 .mediaFrameHero {

--- a/src/app/lab/[slug]/ProjectMedia.tsx
+++ b/src/app/lab/[slug]/ProjectMedia.tsx
@@ -29,8 +29,10 @@ export default function ProjectMedia({ frames, title, fit }: ProjectMediaProps) 
             key={src}
             type="button"
             // Opted out of the global cursor envelope: a difference-blend blob
-            // over a photo reads as a broken negative, not as a highlight.
+            // over a photo reads as a broken negative, not as a highlight. The
+            // cursor carries a "+" affordance instead of a fixed corner badge.
             data-local-magnetic="true"
+            data-cursor-glyph="+"
             className={`${styles.mediaFrame} ${styles.mediaFrameClickable} ${
               i === 0 && frames.length > 1 ? styles.mediaFrameHero : ""
             }`}
@@ -47,9 +49,6 @@ export default function ProjectMedia({ frames, title, fit }: ProjectMediaProps) 
               sizes={i === 0 ? "(max-width: 768px) 100vw, 860px" : "(max-width: 768px) 50vw, 430px"}
               priority={i === 0}
             />
-            <span className={styles.mediaZoomHint} aria-hidden="true">
-              +
-            </span>
           </button>
         ))}
       </div>

--- a/src/app/lab/page.module.scss
+++ b/src/app/lab/page.module.scss
@@ -358,6 +358,9 @@
   padding: $spacing-xs 0;
   transition: opacity 0.15s ease;
   min-height: $touch-target-min;
+  // Full stadium corner so the cursor envelope wraps this wide, short toggle
+  // as a pill: 12px on a bare button this size reads as a hard rectangle.
+  border-radius: $radius-full;
 
   &:hover { opacity: 1; }
 }

--- a/src/components/atoms/custom-cursor/CustomCursor.module.scss
+++ b/src/components/atoms/custom-cursor/CustomCursor.module.scss
@@ -13,6 +13,43 @@
   mix-blend-mode: difference;
 }
 
+// Contextual affordance ("+" / "−") drawn where the dot would be. Same silk
+// fill blended as a negative so it inverts whatever it sits over, matching the
+// dot and the blob on both themes.
+.cursorGlyph {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: $size-cursor-ring;
+  height: $size-cursor-ring;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 1000002;
+  color: $color-silk-light;
+  font-family: $font-family-mono;
+  font-size: $font-size-lg;
+  font-weight: 700;
+  line-height: 1;
+  mix-blend-mode: difference;
+  // Reveal uses the independent `scale` property, not `transform`: Framer drives
+  // the follow via `transform`, so keeping the two on separate properties lets
+  // them compose instead of overwriting each other.
+  scale: 0;
+  opacity: 0;
+  transition: scale 0.15s ease, opacity 0.15s ease;
+
+  &[data-active="true"] {
+    scale: 1;
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
 .cursorBlob {
   position: fixed;
   top: 0;

--- a/src/components/atoms/custom-cursor/CustomCursor.tsx
+++ b/src/components/atoms/custom-cursor/CustomCursor.tsx
@@ -66,6 +66,11 @@ export default function CustomCursor() {
   // iPadOS-style pointer adoption: while a compact control is hovered the
   // blob stretches to the control's box and the dot melts into it.
   const [envelope, setEnvelope] = useState<Envelope | null>(null);
+  // Contextual affordance drawn in place of the dot: "+" over a zoomable image,
+  // "−" inside the open lightbox. Any element carrying `data-cursor-glyph`
+  // sets it, as long as the pointer is not adopting a control.
+  const [glyph, setGlyph] = useState<string | null>(null);
+  const glyphRef = useRef<string | null>(null);
 
   const pathname = usePathname();
 
@@ -102,6 +107,20 @@ export default function CustomCursor() {
       resetMagnetElement(activeMagnetRef.current);
       activeMagnetRef.current = null;
       setEnvelope(null);
+    };
+
+    const setGlyphFor = (source: HTMLElement | null, enveloping: boolean) => {
+      // The envelope wins: adopting a control (e.g. the lightbox close button)
+      // must not also paint a "−" over it.
+      const next = enveloping
+        ? null
+        : (source?.closest("[data-cursor-glyph]") as HTMLElement | null)?.getAttribute(
+            "data-cursor-glyph",
+          ) ?? null;
+      if (next !== glyphRef.current) {
+        glyphRef.current = next;
+        setGlyph(next);
+      }
     };
 
     // Applies magnetism and returns the blob's target point: the (parallax-
@@ -174,6 +193,7 @@ export default function CustomCursor() {
       const target = applyGlobalMagnetism(e);
       blobX.set(target.x);
       blobY.set(target.y);
+      setGlyphFor(e.target as HTMLElement | null, activeMagnetRef.current !== null);
     };
 
     const handleMouseDown = () => setIsClicking(true);
@@ -241,6 +261,7 @@ export default function CustomCursor() {
       window.removeEventListener("blur", clearMagnetism);
       window.removeEventListener("scroll", clearMagnetism, { capture: true });
       clearMagnetism();
+      glyphRef.current = null;
     };
   }, [mouseX, mouseY, blobX, blobY]);
 
@@ -250,21 +271,38 @@ export default function CustomCursor() {
     setIsHovering(false);
     setIsClicking(false);
     setEnvelope(null);
+    setGlyph(null);
+    glyphRef.current = null;
   }, [pathname]);
 
   if (!isVisible) return null;
 
   return (
     <>
-      {/* Central Dot (Instant Follow) — melts into the enveloped control */}
+      {/* Central Dot (Instant Follow) — melts into the enveloped control, and
+          steps aside for the contextual glyph. */}
       <motion.div
         className={styles.cursorDot}
         style={{ translateX: mouseX, translateY: mouseY, x: "-50%", y: "-50%" }}
         animate={{
-          scale: envelope ? 0 : isClicking ? 0.8 : isHovering ? 0.5 : 1,
+          scale: envelope || glyph ? 0 : isClicking ? 0.8 : isHovering ? 0.5 : 1,
         }}
         transition={{ duration: 0.15 }}
       />
+
+      {/* Contextual glyph (Instant Follow) — the affordance the blob carries:
+          "+" to zoom into an image, "−" to leave the open viewer. Blended as a
+          negative like the dot so it reads on any background. Framer owns the
+          follow transform; the reveal uses the independent CSS `scale`
+          property (see the module) so the two never fight over `transform`. */}
+      <motion.div
+        className={styles.cursorGlyph}
+        data-active={glyph ? "true" : undefined}
+        style={{ translateX: mouseX, translateY: mouseY, x: "-50%", y: "-50%" }}
+        aria-hidden="true"
+      >
+        {glyph}
+      </motion.div>
 
       {/* Outer Blob (Spring Follow + Wave Morph). While a compact control is
           hovered it adopts the control: stretches to its box, takes its

--- a/src/components/molecules/lightbox/Lightbox.tsx
+++ b/src/components/molecules/lightbox/Lightbox.tsx
@@ -155,6 +155,9 @@ export default function Lightbox({
       role="dialog"
       aria-modal="true"
       aria-label={`${title} gallery`}
+      // The cursor carries a "−" here (click the backdrop to close); the
+      // toolbar buttons override it with the normal envelope.
+      data-cursor-glyph="−"
       onClick={onClose}
     >
       <div className={styles.topBar} onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
## What

Two things Ivan spotted while browsing the site.

### Cursor carries the zoom affordance
Instead of a fixed \"+\" badge pinned in each gallery frame, the cursor itself becomes the affordance:
- **\"+\"** while hovering a zoomable image (the frame opts out of the blob envelope, so the glyph rides inside the blob as a negative).
- **\"−\"** anywhere inside the open lightbox, to leave it.

Any element opts in with `data-cursor-glyph`. The iPadOS pointer envelope wins over the glyph, so adopting a control (the lightbox toolbar buttons) never also paints a \"−\".

Implementation note: the glyph reveal animates via the independent CSS `scale` property, not `transform` — Framer owns the follow transform, and keeping them on separate properties stops them overwriting each other. The `mix-blend-mode: difference` stays on the outer element so it reads as a negative on both themes.

### Archive toggle is no longer square
The Work \"Archive\" toggle was a bare, transparent button with no corner radius, so the cursor envelope fell back to a hard 12px rectangle and read as square. It now carries a full stadium radius, so the envelope wraps it as a pill.

## Verify
- 120/120 jest, eslint clean, production build green (`/lab/[slug]` still static).
- Headless Chromium: \"+\" shows over image frames (opacity/scale 1), \"−\" shows in the open lightbox, and the archive envelope is a 999px stadium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)