### PR TITLE
fix: lightbox click-to-zoom cursor + derive all colours from tokens

### DIFF
--- a/src/app/admin/page.module.scss
+++ b/src/app/admin/page.module.scss
@@ -121,9 +121,9 @@
   font-family: $font-family-mono;
   font-size: $font-size-sm;
   color: $color-warning;
-  background-color: rgba(250, 204, 21, 0.07);
-  border-top: $border-hairline solid rgba(250, 204, 21, 0.35);
-  border-bottom: $border-hairline solid rgba(250, 204, 21, 0.35);
+  background-color: rgba($color-warning, 0.07);
+  border-top: $border-hairline solid rgba($color-warning, 0.35);
+  border-bottom: $border-hairline solid rgba($color-warning, 0.35);
   padding: 0.45rem 2rem;
   letter-spacing: $letter-spacing-sm;
   text-align: center;
@@ -304,7 +304,7 @@
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba($color-black, 0.7);
   backdrop-filter: blur($blur-sm);
   z-index: 100;
   display: flex;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#f4f5f7" },
+    { media: "(prefers-color-scheme: light)", color: DESIGN_SYSTEM.color.manifestLight },
     { media: "(prefers-color-scheme: dark)", color: DESIGN_SYSTEM.color.brandDark },
   ],
 };

--- a/src/components/molecules/lightbox/Lightbox.module.scss
+++ b/src/components/molecules/lightbox/Lightbox.module.scss
@@ -86,6 +86,17 @@
   &[data-dragging] {
     cursor: grabbing;
   }
+
+  // Desktop drives the affordance through the custom cursor and its +/- glyph,
+  // so hide the native cursor here too — otherwise it stacks on top. Mirrors
+  // the site-wide `cursor: none` on interactive elements.
+  @media (hover: hover) and (pointer: fine) {
+    &,
+    &[data-zoomed],
+    &[data-dragging] {
+      cursor: none;
+    }
+  }
 }
 
 .canvas {

--- a/src/components/molecules/lightbox/Lightbox.tsx
+++ b/src/components/molecules/lightbox/Lightbox.tsx
@@ -39,6 +39,10 @@ export default function Lightbox({
   const stageRef = useRef<HTMLDivElement>(null);
   const pointersRef = useRef(new Map<number, { x: number; y: number }>());
   const pinchRef = useRef<{ dist: number; zoom: number } | null>(null);
+  // Tell a click apart from the tail of a pan/pinch: a pointer that moved is a
+  // drag and must not also toggle the zoom.
+  const downRef = useRef({ x: 0, y: 0 });
+  const movedRef = useRef(false);
 
   const zoomRef = useRef(zoom);
   useEffect(() => {
@@ -111,6 +115,8 @@ export default function Lightbox({
   const onPointerDown = (e: React.PointerEvent) => {
     (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
     pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    downRef.current = { x: e.clientX, y: e.clientY };
+    movedRef.current = false;
     if (pointersRef.current.size === 2) {
       const [a, b] = [...pointersRef.current.values()];
       pinchRef.current = { dist: Math.hypot(a.x - b.x, a.y - b.y), zoom: zoomRef.current };
@@ -123,6 +129,8 @@ export default function Lightbox({
     const prev = pointersRef.current.get(e.pointerId);
     if (!prev) return;
     pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (Math.hypot(e.clientX - downRef.current.x, e.clientY - downRef.current.y) > 4)
+      movedRef.current = true;
 
     if (pointersRef.current.size === 2 && pinchRef.current) {
       const [a, b] = [...pointersRef.current.values()];
@@ -141,9 +149,28 @@ export default function Lightbox({
     if (pointersRef.current.size === 0) setDragging(false);
   };
 
-  const onDoubleClick = () => {
-    if (zoomRef.current > MIN_ZOOM) resetView();
-    else applyZoom(DBLCLICK_ZOOM);
+  // Single click is the primary zoom control: zoom in toward the click when at
+  // rest, zoom back out when already magnified. stopPropagation keeps the click
+  // from reaching the backdrop (which closes the viewer). A click that was
+  // really the end of a drag is ignored.
+  const onStageClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (movedRef.current) return;
+    if (zoomRef.current > MIN_ZOOM) {
+      resetView();
+      return;
+    }
+    const stage = stageRef.current;
+    if (!stage) {
+      applyZoom(DBLCLICK_ZOOM);
+      return;
+    }
+    const r = stage.getBoundingClientRect();
+    const px = e.clientX - (r.left + r.width / 2);
+    const py = e.clientY - (r.top + r.height / 2);
+    // Keep the clicked point under the cursor: offset = p * (1 - zoom).
+    setZoom(DBLCLICK_ZOOM);
+    setOffset(clampOffset({ x: px * (1 - DBLCLICK_ZOOM), y: py * (1 - DBLCLICK_ZOOM) }, DBLCLICK_ZOOM));
   };
 
   const frameName =
@@ -155,9 +182,6 @@ export default function Lightbox({
       role="dialog"
       aria-modal="true"
       aria-label={`${title} gallery`}
-      // The cursor carries a "−" here (click the backdrop to close); the
-      // toolbar buttons override it with the normal envelope.
-      data-cursor-glyph="−"
       onClick={onClose}
     >
       <div className={styles.topBar} onClick={(e) => e.stopPropagation()}>
@@ -174,12 +198,13 @@ export default function Lightbox({
         className={styles.stage}
         data-dragging={dragging || undefined}
         data-zoomed={zoom > MIN_ZOOM || undefined}
-        onClick={(e) => e.stopPropagation()}
+        // The cursor becomes "+" (zoom in) or "−" (zoom out) over the image.
+        data-cursor-glyph={zoom > MIN_ZOOM ? "−" : "+"}
+        onClick={onStageClick}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
-        onDoubleClick={onDoubleClick}
       >
         <div
           className={styles.canvas}
@@ -220,7 +245,7 @@ export default function Lightbox({
           </>
         ) : (
           <Text as="span" variant="label" className={styles.counter}>
-            scroll to zoom · drag to pan
+            click to zoom · drag to pan
           </Text>
         )}
       </div>

--- a/src/components/molecules/particle-logo/ParticleLogo.tsx
+++ b/src/components/molecules/particle-logo/ParticleLogo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTheme } from "@/context/ThemeContext";
+import { DESIGN_SYSTEM } from "@/styles/design-system";
 import { Html } from "@react-three/drei";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { useReducedMotion } from "framer-motion";
@@ -28,8 +29,8 @@ function InteractiveParticles() {
   const color = useMemo(
     () =>
       theme === "dark"
-        ? new THREE.Color("#A78BFA")
-        : new THREE.Color("#3B82F6"),
+        ? new THREE.Color(DESIGN_SYSTEM.color.voltaDark)
+        : new THREE.Color(DESIGN_SYSTEM.color.larioLight),
     [theme],
   );
 

--- a/src/components/organisms/fus-ro-dah/FusRoDah.module.scss
+++ b/src/components/organisms/fus-ro-dah/FusRoDah.module.scss
@@ -190,8 +190,8 @@
     90deg,
     transparent 0px,
     transparent 38px,
-    rgba(255, 255, 255, 0.035) 38px,
-    rgba(255, 255, 255, 0.035) 40px
+    rgba($color-white, 0.035) 38px,
+    rgba($color-white, 0.035) 40px
   );
   animation: windBlast 0.9s ease-out forwards;
 }

--- a/src/components/organisms/liquid-surface/LiquidSurface.module.scss
+++ b/src/components/organisms/liquid-surface/LiquidSurface.module.scss
@@ -3,7 +3,7 @@
 .wrapper {
   width: 100%;
   height: 100vh;
-  background-color: #000;
+  background-color: $color-black;
   overflow: hidden;
   position: relative;
 }

--- a/src/context/ThemeContext.module.scss
+++ b/src/context/ThemeContext.module.scss
@@ -8,6 +8,6 @@
   background: radial-gradient(
     circle 350px at var(--spotlight-x, 0px) var(--spotlight-y, 0px),
     transparent 0%,
-    rgba(0, 0, 0, 0.98) 100%
+    rgba($color-black, 0.98) 100%
   );
 }


### PR DESCRIPTION
## Lightbox zoom (the \"a volte zooma a volte no\")
The viewer only zoomed on **double**-click, while a single click on the backdrop **closed** it — so clicking felt random. Now:

- **Single click is the zoom control**: zooms in toward the clicked point when at rest, zooms back out when already magnified.
- **The cursor glyph reflects the state**: `+` to zoom in, `−` to zoom out (was a fixed `−`).
- **Drag-to-pan is safe**: a click that was actually the tail of a pan is ignored, so panning no longer snaps the zoom off.
- **No double cursor**: the stage hid the native `zoom-in`/`grab` cursor on desktop, which was stacking under the custom cursor + glyph.

Close is still `ESC` (button + key) and clicking the dark margins.

## 100% design-system colours
Swept the styles for colour literals that did not derive from a token and routed them through the existing ones — **identical output**, now named:

| Was | Now |
|---|---|
| `rgba(250,204,21,…)` (admin banner) | `rgba($color-warning, …)` |
| `rgba(0,0,0,…)` (admin scrim, theme spotlight) | `rgba($color-black, …)` |
| `rgba(255,255,255,…)` (fus-ro-dah scanlines) | `rgba($color-white, …)` |
| `#000` (liquid-surface bg) | `$color-black` |
| `#f4f5f7` (layout light theme-color) | `DESIGN_SYSTEM.color.manifestLight` |
| `#A78BFA` / `#3B82F6` (particle-logo) | `DESIGN_SYSTEM.color.voltaDark` / `larioLight` |

The SCSS layer now has **zero raw colour literals** outside the token-defining files. The only hand-written colours left are the WebGL shader art uniforms (cyan neon, void blue, vortex purples) that have no token equivalent — flagged, not changed.

## Verify
- 120/120 jest, eslint clean, production build green (`/lab/[slug]` still static).
- Headless Chromium: click zooms in to 2.5x toward the click (glyph flips to `−`), re-click resets (glyph `+`), drag pans while staying zoomed, native cursor is `none` on the stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)